### PR TITLE
Detector Status and Status Log Updater

### DIFF
--- a/data_helpers.py
+++ b/data_helpers.py
@@ -17,15 +17,7 @@ def filter_by_key(data, key, val_list):
     #  filter a list of dictionaries by a list of key values
     #  assumes input dicts contain relevant keys
     #  http://stackoverflow.com/questions/29051573/python-filter-list-of-dictionaries-based-on-key-value
-    return [d for d in data if d[key] in val_list]  
-
-
-def filter_by_key(data, key, val_list):
-    print('filter by key {}'.format(key))
-    #  filter a list of dictionaries by a list of key values
-    #  http://stackoverflow.com/questions/29051573/python-filter-list-of-dictionaries-based-on-key-value
-    return [d for d in data if d[key] in val_list]  
-
+    return [d for d in data if d[key] in val_list]
 
 def filter_by_key_exists(data, key):
     'filter by key exists: {}'.format(key)

--- a/detection_status.py
+++ b/detection_status.py
@@ -1,0 +1,234 @@
+'''
+Assign detection status to traffic signal based on status of its detectors. 
+Update detection status log when signal detection status changes.
+'''
+import os
+import logging
+import traceback
+from collections import defaultdict
+import pdb
+import arrow
+import data_helpers
+import knack_api as kn
+import secrets
+
+def groupBySignal(detector_data):
+    '''
+    Group signal detector status and status date according to parent signal. 
+
+     Parameters
+    ----------
+    detector_data : list | (required)
+        List of dicts where each dict contains vehicle detector data
+        retrieved from Knack view. attributes include signal id, detector
+        status, and detector status date. 
+
+    Returns
+    -------
+    det_status : dict
+        Each key in dict is a traffic signal id with keys statuses (an array of detector
+        statuses) and dates (an array of detector status dates). This dict will be used to
+        determine most current status and date. see methond getStatus().
+    '''
+    det_status = defaultdict(dict)
+
+    for det in  detector_data:
+        if 'SIGNAL_ID' in det and DET_STATUS_LABEL in det and DET_DATE_LABEL in det:
+            sig = '${}'.format(det['SIGNAL_ID'])  #  format signal ID as string 
+            status = det[DET_STATUS_LABEL]
+            status_date = det[DET_DATE_LABEL]
+            
+            if sig not in det_status:
+                det_status[sig]['statuses'] = [status]
+                det_status[sig]['dates'] = [status_date]
+            else:
+                det_status[sig]['statuses'].append(status)
+                det_status[sig]['dates'].append(status_date)
+
+    return det_status
+
+
+def getStatus(sig, det_status):
+    '''
+    Determine a signal's detection status based on the status
+    of its detectors
+
+    Parameters
+    ----------
+    sig : dict | (required)
+        A signal record dict generated from a Knack.View instance
+    det_status : dict | (required)
+        A lookup dictionary generated from method groupBySignal()
+
+    Returns
+    -------
+    value : string
+        A detection status string of BROKEN, UNKNOWN, NO DETECTIO, OK
+    '''
+    sig_id = '${}'.format(sig['SIGNAL_ID'])
+
+    if sig_id in det_status:
+        #  any broken detector, status is BROKEN
+        if 'BROKEN' in det_status[sig_id]['statuses']:
+            return 'BROKEN'
+        #  any unknown detector, status is UNKNOWN
+        if 'UNKNOWN' in det_status[sig_id]['statuses']:
+            return 'UNKNOWN'
+        #  detection has been removed and not updated, or who knows what
+        if 'OK' not in det_status[sig_id]['statuses']:
+            return 'UNKNOWN'
+        #  detection must be OK
+        return 'OK'
+    else:
+        #  no detectors at signal
+        return  'NO DETECTION'
+
+def getMaxDate(sig, det_status):
+    '''
+    Determine a signal's most recent status date status 
+
+    Parameters
+    ----------
+    sig : dict | (required)
+        A signal record dict generated from a Knack.View instance
+    det_status : dict | (required)
+        A lookup dictionary generated from method groupBySignal()
+
+    Returns
+    -------
+    value : int
+        A timestamp of the maximum (ie most recent) detection status date
+    '''
+    sig_id = '${}'.format(sig['SIGNAL_ID'])
+
+    if sig_id in det_status:
+        return max([int(t) for t in det_status[sig_id]['dates'] ])
+    else:
+        return arrow.now().format('MM-DD-YYYY')
+
+if __name__ == '__main__':
+
+    now = arrow.now()
+    now_s = now.format('YYYY_MM_DD')
+
+    #  init logging 
+    log_directory = secrets.LOG_DIRECTORY
+    cur_dir = os.path.dirname(__file__)
+    logfile = '{}/detection_status_{}.log'.format(log_directory, now_s)
+    log_path = os.path.join(cur_dir, logfile)
+    logging.basicConfig(filename=log_path, level=logging.INFO)
+    logging.info('START AT {}'.format(str(now)))
+
+    try:
+        #  field labels on detector object that provides source status and date
+        DET_STATUS_LABEL = 'DETECTOR_STATUS'
+        DET_DATE_LABEL = 'MODIFIED_DATE'
+        #  field labels on signals object that will receive status and date
+        SIG_STATUS_LABEL = 'DETECTION_STATUS'
+        SIG_DATE_LABEL = 'DETECTION_STATUS_DATE'
+
+        #  Knack API config
+        api_key = secrets.KNACK_CREDENTIALS['api_key']
+        app_id = secrets.KNACK_CREDENTIALS['app_id']
+
+        config_detectors = {
+            'scene' : 'scene_468',
+            'view' : 'view_1333',
+            'objects' : ['object_98']
+        }
+
+        config_signals = {
+            'scene' : 'scene_73',
+            'view' : 'view_197',
+            'objects' : ['object_12']
+        }
+
+        config_status_log = {
+            'objects' : ['object_102']
+        }
+
+        fieldmap_status_log = {
+            "EVENT" : 'field_1576',
+            "SIGNAL" : 'field_1577',
+            "EVENT_DATE" : 'field_1578'
+        }
+
+        #  get detector data
+        detectors = kn.View(scene=config_detectors['scene'], view=config_detectors['view'], field_obj=config_detectors['objects'], api_key=api_key, app_id=app_id)
+
+        #  get signal data
+        signals = kn.View(scene=config_signals['scene'], view=config_signals['view'], field_obj=config_signals['objects'], api_key=api_key, app_id=app_id)
+        signals.data_parsed = data_helpers.filter_by_key(signals.data_parsed, 'SIGNAL_STATUS', ['TURNED_ON'])
+
+        #  staging dict
+        lookup = groupBySignal(detectors.data_parsed)
+
+        #  record update count
+        count_sig = 0
+        count_status = 0
+
+        #  iterate through signals, get status, update record in Knack database
+        for sig in signals.data_parsed:
+            
+            old_status = None
+            new_status = getStatus(sig, lookup)
+            new_status_date = getMaxDate(sig, lookup)
+            
+            if SIG_STATUS_LABEL in sig:
+                old_status = sig[SIG_STATUS_LABEL]
+
+                if old_status == new_status:
+                    #  no change in status
+                    continue
+
+            payload_signals = {
+                'KNACK_ID' : sig['KNACK_ID'],
+                SIG_STATUS_LABEL : new_status,
+                SIG_DATE_LABEL : getMaxDate(sig, lookup)
+            }
+
+            #  replace field labels with database fieldnames
+            payload_signals = data_helpers.replace_keys([payload_signals], signals.field_map)
+
+            #  update signal record with detection status and date
+            res = kn.update_record(payload_signals[0], config_signals['objects'][0], 'KNACK_ID', app_id, api_key)
+        
+            count_sig += 1
+    
+            #  update signal status log
+            if not old_status and new_status == 'OK':  # detection is new
+                event = 'DETECTION INSTALLED'
+            elif new_status == 'OK' and old_status != 'OK':  #  detection restored
+                event = 'DETECTION RESTORED'
+            elif new_status == 'NO DETECTION':  #  detection uninstalled
+                event = 'DETECTION UNINSTALLED'
+            else:
+                event = 'ISSUE REPORTED'  #  detection not ok
+
+            payload_status_log = {
+                'EVENT' : event,
+                'EVENT_DATE' : new_status_date,
+                'SIGNAL' : [sig['KNACK_ID']],  #  signal connection field is passed as an array of length 1
+            }
+            
+            #  replace field labels with database fieldnames
+            payload_status_log = data_helpers.replace_keys([payload_status_log], fieldmap_status_log)
+            
+            #  update signal detection status log
+            res = kn.insert_record(payload_status_log[0], config_status_log['objects'][0], app_id, api_key)
+            
+            count_status += 1
+
+        logging.info('{} signal records updated'.format(count_sig))
+        logging.info( '{} detection status log records updated'.format(count_status) )
+        logging.info('END AT {}'.format(str( arrow.now().format()) ))
+
+    except Exception as e:
+        print('Failed to process data for {}'.format(date_time))
+        error_text = traceback.format_exc()
+        email_subject = "Detection Status Update Failure".format(dataset)
+        email_helpers.send_email(secrets.ALERTS_DISTRIBUTION, email_subject, error_text)
+        logging.error(error_text)
+        print(e)
+        raise e
+

--- a/knack_api.py
+++ b/knack_api.py
@@ -1,0 +1,390 @@
+import json
+import logging
+import pdb
+import requests
+
+
+class Knack(object):
+
+    def __init__(self, app_id=None, api_key=None, timeout=10):
+        '''  
+        Class to interact with Knack application via the API as
+        documented at https://www.knack.com/developer-documentation/
+        
+        Parameters
+        ----------
+        app_id : string (required)
+            Knack application ID string
+        api_key : string (optional | default : None )
+            Knack application key. Required for accessing private views.
+        timeout : numeric (optional | default: 10)
+            number of seconds before http request timeout
+        '''
+        self.app_id = app_id
+        self.api_key = api_key
+        
+        if not app_id:
+            raise Exception('app_id is required.')
+
+        if not api_key:
+            logging.warning("API key is required to access private views.")
+
+        self.timeout = float(timeout)
+
+
+    def get_fields(self, objects, rows_per_page=1000):
+        '''
+        Get field data from Knack objects
+        
+        Parameters
+        ----------
+        rows_per_page : int (optional | default: 1000 | max: 1000)
+            The number of rows to return per page (i.e. API call). 
+
+        Returns
+        -------
+        fields : list
+            A list of dictionaries where each dict is a Knack field 
+        '''
+        print('get field data')
+        objects_url = 'https://api.knack.com/v1/objects/'
+
+        fields = []
+        raw_fields = {}
+
+        headers = { 'x-knack-application-id': self.app_id, 'x-knack-rest-api-key': self.api_key }
+
+        try:
+            req = requests.get(objects_url, headers=headers)
+
+        except requests.exceptions.HTTPError as e:
+            raise e
+
+        data = req.json()['objects']  #  get all database objects
+
+        for obj in data:  
+            
+            if obj['key'] in objects:  #  get field metadata for specified objects
+
+                current_object = obj['key']
+                url = '{}{}/fields?rows_per_page=1000'.format(objects_url, current_object)
+
+                try:
+                    req = requests.get(url, headers=headers)
+
+                except requests.exceptions.HTTPError as e:
+                    raise e
+
+                fields = fields + req.json()['fields']
+
+        for field in fields:
+            if field['key'] + '_raw' not in raw_fields:
+                '''
+                not all Knack fields have a 'raw' object
+                so create one here
+                '''
+                raw_fields[field['key'] + '_raw'] = field  # 
+        
+        self.fields = raw_fields
+        return self.fields
+
+    def create_field_map(self, parse_raw=False): 
+        field_map = {}
+        
+        for field in self.fields:
+            if parse_raw:
+                new_field = field.replace('_raw', '')
+
+            field_map[self.fields[field]['label']] = new_field
+
+        self.field_map = field_map
+        return self.field_map
+
+    def parse_data(self, include_ids=False, require_locations=False, convert_to_unix=False, raw_connections=False, id_outfield='KNACK_ID'):
+        print('parse knack data')
+        #  create a happy list of dicts from raw knack data
+        #  data is a list of dicts from knack database
+        #  option include_ids adds a field for the Knack DB IDs
+        #  knack ID outfield is 'KNACK_ID' unless specified in option 'id_outfield'
+        #  option require_location throws out records missing a 'LONGITUDE' field
+
+        parsed_data = []
+
+        count = 0
+
+        for record in self.data:
+     
+            count += 1
+
+            new_record = {}  #  parsed record goes here
+            
+            for key in record:  
+
+                if type(record[key]) is str:
+                    
+                    record[key] = record[key].strip()
+
+                    if record[key] == '':
+                        continue  #  ignore empty fields
+
+                if type(record[key]) is list:
+                    if not record[key]:
+                        continue  #  ignore empty fields
+
+                if key in self.fields:
+                    field_label = self.fields[key]['label']
+
+                    field_type = self.fields[key]['type']
+
+                else:
+                    continue
+
+                if field_type == 'address':  #  converts location field to lat/lon  
+
+                    new_record['LATITUDE'] = record[key]['latitude']
+
+                    new_record['LONGITUDE'] = record[key]['longitude']
+
+                elif field_type == 'date':
+                    new_record[field_label] = record[key]['unix_timestamp']
+                    
+                    if convert_to_unix:
+                        new_record[field_label] = int( float(new_record[field_label]) / 1000 ) 
+                
+                elif field_type == 'date_time':
+                    new_record[field_label] = record[key]['unix_timestamp']
+
+                    if convert_to_unix:
+                        new_record[field_label] =  int( float(new_record[field_label]) / 1000 )
+
+                elif field_type == 'connection':
+
+                    if raw_connections:
+                        new_record[field_label] = record[key]
+                    
+                    else:
+                        new_record[field_label] = record[key][0]['identifier']
+
+                else:
+                    new_record[field_label] = record[key]
+
+            if include_ids:
+                id_outfield = id_outfield
+                
+                new_record[id_outfield] = record['id']
+
+            if require_locations:
+                
+                if  'LONGITUDE' in new_record:
+                    parsed_data.append(new_record)
+
+            else:
+                parsed_data.append(new_record)
+
+        self.data_parsed = parsed_data
+
+        return self.data_parsed
+
+class View(Knack):
+    def __init__(self, scene, view, field_obj=None, app_id=None, api_key=None, timeout=10):
+        Knack.__init__(self, app_id, api_key, timeout)
+        
+        '''
+        Class to fetch data from a Knack application view via the API as
+        documented at https://www.knack.com/developer-documentation/
+        
+        Parameters
+        ----------
+        scene : string (required)
+            Knack scene identifer in format "scene_xx"
+        view : string (required)
+            Knack view identifier in format "view_xx"
+        app_id : string (required)
+            Knack application ID string
+        api_key : string (optional | default : None )
+            Knack application key. Required for accessing private views.
+        fied_objects : list (optional | default : None)
+            List of knack objects which are referefeced by the instance's view.
+            Format "object_xx". Required for retrieving field data
+        timeout : numeric (optional | default: 10)
+            number of seconds before http request timeout
+        '''
+        self.scene = scene
+        self.view = view
+        self.field_obj = field_obj
+        #  get field data and send to self.fields
+        self.get_fields(self.field_obj)
+        #  create field map and send to self.field_map
+        self.create_field_map(parse_raw=True)
+        #  get data and send to self.data
+        self.data_from_view()
+
+        if self.data and self.field_map:
+            #  parse data and send to self.data_parsed
+            self.parse_data(include_ids=True)
+
+    def data_from_view(self, rows_per_page=1000):
+        '''
+        Get data from Knack view
+        
+        Parameters
+        ----------
+        rows_per_page : int (optional | default: 1000 | max: 1000)
+            The number of rows to return per page (i.e. API call). 
+
+        Returns
+        -------
+        data : list
+            A list of dictionaries where each dict is a Knack record
+        '''
+        print("Get data from view {}".format(self.view))
+        url = 'https://api.knack.com/v1/pages/{}/views/{}/records?rows_per_page={}'.format( self.scene, self.view, rows_per_page)
+        current_page = 1
+        headers = { 'x-knack-application-id': self.app_id, 'x-knack-rest-api-key': self.api_key }
+        params = {'page':current_page}
+
+        try:
+            req = requests.get(url, headers=headers, params=params)
+
+        except requests.exceptions.HTTPError as e:
+            raise e
+
+        data = req.json()['records']
+
+        if (req.json()['total_pages'] > 1):
+            total_pages = req.json()['total_pages']
+
+            while current_page < total_pages: #  page numbers start at 0
+                current_page = current_page + 1
+                params = {'page':current_page}
+
+                try:
+                    req = requests.get(url, headers=headers, params=params)
+                    data = data + req.json()['records']
+                
+                except requests.exceptions.HTTPError as e:
+                    raise e
+
+        print("retrieved {} records".format(len(data)))
+        
+        self.data = data
+        return self.data
+
+
+class Obj(Knack):
+    '''
+    Class to fetch data from a Knack object via the API as
+    documented at https://www.knack.com/developer-documentation/
+    
+    Parameters
+    ----------
+    obj : string (required)
+        Knack object identifer in format "object_xx"
+    app_id : string (required)
+        Knack application ID string
+    api_key : string (optional | default : None )
+        Knack application key. Required for accessing private views.
+    timeout : numeric (optional | default: 10)
+        number of seconds before http request timeout
+    '''
+    def __init__(self, obj, app_id=None, api_key=None, timeout=10):
+        Knack.__init__(self, app_id, api_key, timeout)       
+
+        self.obj = obj
+        #  get field data and send to self.fields
+        self.get_fields([self.obj])
+        #  create field map and send to self.field_map
+        self.create_field_map(parse_raw=True)
+        #  get data and send to self.data
+        self.data_from_obj()
+
+        self.data_parsed = None
+        if self.data and self.field_map:
+            #  parse data and send to self.data_parsed
+            self.parse_data(include_ids=True)
+
+    def data_from_obj(self, rows_per_page=1000):
+        print('hey');   
+        '''
+        fetch knack data directly from knack table ('object') 
+        instead ofr from a page view
+        '''
+        print('get data from knack object')
+        
+        url = 'https://api.knack.com/v1/objects/{}/records?rows_per_page=1000'.format( self.obj ) 
+
+        current_page = 1
+        
+        headers = { 'x-knack-application-id': self.app_id, 'x-knack-rest-api-key': self.api_key }
+        
+        params = {'page':current_page}
+
+        try:
+            req = requests.get(url, headers=headers, params=params)
+
+        except requests.exceptions.HTTPError as e:
+            raise e
+
+        data = req.json()['records']
+
+        if (req.json()['total_pages'] > 1):
+
+            total_pages = req.json()['total_pages']
+
+            while current_page < total_pages: #  page numbers start at 0
+
+                current_page = current_page + 1
+
+                params = {'page':current_page}
+
+                try:
+                    req = requests.get(objects_url, headers=headers, params=params)
+
+                    data = data + req.json()['records']
+                
+                except requests.exceptions.HTTPError as e:
+                    raise e
+
+        print("retrieved {} records".format(len(data)))
+
+        self.data = data
+        return self.data
+
+
+
+
+def update_record(record_dict, knack_object, id_key, app_id, api_key):
+    #  record object must have 'KNACK_ID' field
+    print('update knack record')
+
+    knack_id = record_dict[id_key]  #  extract knack ID and remove from update object
+
+    del record_dict[id_key]
+
+    update_url = 'https://api.knack.com/v1/objects/{}/records/{}'.format(knack_object, knack_id)
+
+    headers = { 'x-knack-application-id': app_id, 'x-knack-rest-api-key': api_key, 'Content-type': 'application/json'}
+    
+    try:
+        req = requests.put(update_url, headers=headers, json=record_dict)
+
+    except requests.exceptions.HTTPError as e:
+        raise e
+
+    return req.json()
+    
+
+def insert_record(record_dict, knack_object, app_id, api_key):
+    print('update knack record')
+    
+    insert_url = 'https://api.knack.com/v1/objects/{}/records'.format(knack_object)
+    
+    headers = { 'x-knack-application-id': app_id, 'x-knack-rest-api-key': api_key, 'Content-type': 'application/json'}
+
+    try:
+        req = requests.post(insert_url, headers=headers, json=record_dict)
+
+    except requests.exceptions.HTTPError as e:
+        raise e
+
+    return req.json()


### PR DESCRIPTION
The detector status updater script assigns a detection status to traffic signal records based on the status of the signal's detectors. When a signal's detection status changes, a detection status log table is also updated with the change in status.
A signal's detection status and the log of status changes funnel into two of our division's monthly performance meausres: # of signals with working detection, and # of signals at which detection was restored We're doing this as part of our effort to better track traffic detection issues and repairs.