### PR TITLE
Reduce Signal Status Upload Fields to Dataset Keys

### DIFF
--- a/util/socratautil.py
+++ b/util/socratautil.py
@@ -155,6 +155,8 @@ def strip_geocoding(dicts):
         if 'location' in record:
             if 'needs_recoding' in record['location']:
                 del record['location']['needs_recoding']
+            if 'human_address' in record['location']:
+                del record['location']['human_address']
 
     return dicts
 


### PR DESCRIPTION
This commit ensures that only fields that only fields in the destination dataset on socrata are included in the fields in the upload payload. The change applies to the signal status publication script, which hits the current signal status dataset (5zpr-dehc) and the historical status dataset (x62n-vjpq).