### PR TITLE
Reduce Signal Status Upload Fields to Dataset Keys

### DIFF
--- a/shell_scripts/location_updater.sh
+++ b/shell_scripts/location_updater.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd ../data_tracker
 source activate datapub1
-python location_updater.py
+python location_updater.py data_tracker_prod
 source deactivate

--- a/util/socratautil.py
+++ b/util/socratautil.py
@@ -155,6 +155,8 @@ def strip_geocoding(dicts):
         if 'location' in record:
             if 'needs_recoding' in record['location']:
                 del record['location']['needs_recoding']
+            if 'human_address' in record['location']:
+                del record['location']['human_address']
 
     return dicts
 


### PR DESCRIPTION
This commit ensures that only fields that only fields in the destination dataset on socrata are included in the fields in the upload payload. The change applies to the signal status publication script, which hits the current signal status dataset (5zpr-dehc) and the historical status dataset (x62n-vjpq).