### PR TITLE
Reduce Signal Status Upload Fields to Dataset Keys

### DIFF
--- a/util/datautil.py
+++ b/util/datautil.py
@@ -7,7 +7,6 @@ import shutil
 import pdb
 
 import arrow
-import pandas
 import requests
 
 
@@ -421,22 +420,7 @@ def replace_keys(dicts, lookup_dict):
         new_dicts.append(new_d)
 
     return new_dicts
-
-
-def write_csv(data, in_memory=False, sep=',', **options):
-    print('Write data to file')
-
-    if not 'file_name' in options:
-        options['file_name'] = '{}'.format( arrow.now().timestamp )
-
-    df = pandas.DataFrame(data)
-
-    if in_memory:
-        return StringIO ( df.to_csv(index=False, sep=sep) )
-
-    else:
-        df.to_csv(options['file_name'], index=False, sep=sep)
-
+    
 
 def get_web_csv(url, encoding='utf-8-sig'):
     req = requests.get(url)

--- a/util/socratautil.py
+++ b/util/socratautil.py
@@ -155,6 +155,8 @@ def strip_geocoding(dicts):
         if 'location' in record:
             if 'needs_recoding' in record['location']:
                 del record['location']['needs_recoding']
+            if 'human_address' in record['location']:
+                del record['location']['human_address']
 
     return dicts
 


### PR DESCRIPTION
This commit ensures that only fields that only fields in the destination dataset on socrata are included in the fields in the upload payload. The change applies to the signal status publication script, which hits the current signal status dataset (5zpr-dehc) and the historical status dataset (x62n-vjpq).