### PR TITLE
Traffic Report Feed ETL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo houses ETL scripts for Austin Transportation's open data projects. The
 
 ## Quick Start
 
-We use [Miniconda](https://conda.io/miniconda.html)) to manage Python environments. If you don't want to use Anaconda, [requirements.txt]() identifies all of the packages required to run the scripts in this repo.
+We use [Anaconda](https://conda.io/miniconda.html) to manage Python environments. If you don't want to use Anaconda, skip step #1 and in step #3 use `pip install -r requirements.txt`.
 
 1. Install [Miniconda](https://conda.io/miniconda.html). Check out the [test drive](https://conda.io/docs/test-drive.html#managing-environments) if you haven't used Anaconda before.
 
@@ -12,7 +12,7 @@ We use [Miniconda](https://conda.io/miniconda.html)) to manage Python environmen
 
 3. `cd` into the repo directory, and run `conda create --name datapub1 --file requirements.txt` to create the data publishing environment
 
-4. Create your `secrets.py` file following the template in [fake-py](https://github.com/cityofaustin/transportation-data-publishing/blob/master/fake_py)
+4. Create your `secrets.py` file following the template in [fake-secrets.py](https://github.com/cityofaustin/transportation-data-publishing/blob/master/config/fake_secrets.py)
 
 ## About the Repo Structure
 

--- a/config/config.py
+++ b/config/config.py
@@ -92,6 +92,38 @@ cfg = {
             'lon' : 'LOCATION_longitude'
         }
     },
+    'pole_attachments' : {
+        'primary_key' : 'POLE_ATTACH_ID',
+        'ref_obj' : ['object_120'],
+        'obj' : None,
+        'scene' : 'scene_589',
+        'view' : 'view_1597',
+        'service_url' : 'http://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/pole_attachments/FeatureServer/0/',
+        'include_ids' : True,
+        'socrata_resource_id' : 'btg5-ebcy',
+        'pub_log_id' : 'n5kp-f8k4',
+        'ip_field' : None,
+        'location_fields' : {
+            'lat' : 'LOCATION_latitude',
+            'lon' : 'LOCATION_longitude'
+        }
+    },
+    'traffic_reports' : {
+        'primary_key' : 'TRAFFIC_REPORT_ID',
+        'ref_obj' : ['object_121'],
+        'obj' : None,
+        'scene' : 'scene_614',
+        'view' : 'view_1626',
+        'service_url' : 'http://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/traffic_reports/FeatureServer/0/',
+        'include_ids' : True,
+        'socrata_resource_id' : 'dx9v-zd7x',
+        'pub_log_id' : 'n5kp-f8k4',
+        'ip_field' : None,
+        'location_fields' : {
+            'lat' : 'LOCATION_latitude',
+            'lon' : 'LOCATION_longitude'
+        }
+    },
     'travel_sensors' : {
         'primary_key' : 'ATD_SENSOR_ID', 
         'ref_obj' : ['object_56', 'object_11'],

--- a/config/traffic_report_fields.py
+++ b/config/traffic_report_fields.py
@@ -1,0 +1,13 @@
+#  Field metadata for the traffic_report object in the AMD data tracker.
+#  Storing the metadata here averts the need to make frquent private API
+#  calls to the Knack API. These fields are periodically refreshed based 
+#  on logic in the traffic_reports.py script.
+TRAFFIC_REPORT_META = {'field_1826': {'label': 'TRAFFIC_REPORT_ID', 'key': 'field_1826', 'required': False, 'type': 'short_text'}, 'field_1833': {'label': 'FOUND_ADDRESS', 'key': 'field_1833', 'required': False, 'type': 'short_text'}, 'field_1827': {'label': 'PUBLISHED_DATE', 'key': 'field_1827', 'required': False, 'type': 'date_time'}, 'field_1828': {'label': 'ADDRESS', 'key': 'field_1828', 'required': False, 'type': 'short_text'}, 'field_1829': {'label': 'ISSUE_REPORTED', 'key': 'field_1829', 'required': False, 'type': 'short_text'}, 'field_1831': {'label': 'LOCATION', 'key': 'field_1831', 'required': False, 'type': 'address'}, 'field_1832': {'label': 'GEOCODE_SCORE', 'key': 'field_1832', 'required': False, 'type': 'number'}, 'field_1837': {'label': 'LATITUDE', 'key': 'field_1837', 'required': False, 'type': 'number'}, 'field_1838': {'label': 'LONGITUDE', 'key': 'field_1838', 'required': False, 'type': 'number'}, 'field_1843': {'label': 'TRAFFIC_REPORT_STATUS', 'key': 'field_1843', 'required': False, 'type': 'multiple_choice', 'choices': ['NEW', 'ARCHIVED']}, 'id': {'key': 'id', 'label': 'id', 'type': 'id'}}
+
+
+
+
+
+
+
+

--- a/data_tracker/traffic_reports.py
+++ b/data_tracker/traffic_reports.py
@@ -1,0 +1,238 @@
+'''
+Parse weird COA traffic report feed,
+look up geometry, and upload to Knack database.
+(A different script publishes the information to the pubic data portal).
+'''
+
+import logging
+import os
+import pdb
+
+import arrow
+import feedparser
+import knackpy
+
+import _setpath
+from config.secrets import *
+from config.traffic_report_fields import *
+from util import emailutil
+from util import datautil
+from util import agolutil
+
+#  init logging 
+now = arrow.now()
+now_s = now.format('YYYY_MM_DD')
+logfile = '{}/traffic_reports{}.log'.format(LOG_DIRECTORY, now_s)
+logging.basicConfig(filename=logfile, level=logging.INFO)
+logging.info('START AT {}'.format(str(now)))
+
+#  config
+feed_url = 'http://www.ci.austin.tx.us/qact/qact_rss.cfm'
+primary_key = 'TRAFFIC_REPORT_ID'
+status_key = 'TRAFFIC_REPORT_STATUS'
+date_field = 'PUBLISHED_DATE'
+knack_obj = 'object_121'
+knack_scene = 'scene_514'
+knack_view = 'view_1624'
+id_field_raw = 'field_1826'
+
+knack_creds = KNACK_CREDENTIALS['data_tracker_prod']
+agol_creds = AGOL_CREDENTIALS
+geocoder = 'http://www.austintexas.gov/GIS/REST/Geocode/COA_Street_Locator/GeocodeServer/findAddressCandidates'
+
+def parseTitle(title):
+    #  assume feed will never have Euro sign (it is non-ascii)
+    title = title.replace('    ', '€')
+
+    #  remove remaining whitespace clumps like so: 
+    title = " ".join(title.split())
+
+    #  split into list on
+    title = title.split('€')
+
+    #  remove empty strings reducing to twoelements
+    #  first is address, second is issue type, with leading dash (-)
+    title = list(filter(None, title))
+
+    issue = title[1].replace('-', '').strip()
+    address = title[0].replace('/', '&')
+    return address, issue
+
+
+def handleGeocode(geocode, record, field_map):
+    #  parse geocode and apply field lookup
+    if 'candidates' in geocode:
+        if geocode['candidates']:
+            y = round(geocode['candidates'][0]['location']['y'], 7)
+            x = round(geocode['candidates'][0]['location']['x'], 7)
+            record[field_map['LOCATION']] = { 'latitude' : y, 'longitude' : x }
+            record[field_map['LATITUDE']] = y
+            record[field_map['LONGITUDE']] = x
+            record[field_map['FOUND_ADDRESS']] = geocode['candidates'][0]['address']
+            record[field_map['GEOCODE_SCORE']] = geocode['candidates'][0]['score']
+        else:
+            return record
+
+    return record
+
+
+def get_filter(field_id, field_val):
+
+    return [
+            {
+               'field' : field_id,
+               'operator' : 'is',
+               'value' : field_val
+            }
+        ]
+    
+def has_match(match_list, val, key):
+    for rec in match_list:
+        print
+        if rec[key] == val:
+            return True
+    return False
+                
+
+def handleDateField(struct_time):
+    #  return a naive millsecond timestamp in local time
+    #  which is good because Knack needs a local timestamp
+    return arrow.get(struct_time).timestamp * 1000
+
+
+def main(date_time):
+
+    try:
+        #  get "ACTIVE" records from knack
+        filter_current = get_filter('field_1843', 'ACTIVE')
+
+        kn = knackpy.Knack(
+            view=knack_view,
+            scene=knack_scene,
+            app_id=knack_creds['app_id'],
+            filters=filter_current,
+            rows_per_page=1000,
+            page_limit=100
+        )
+
+        if not kn.data:
+            #  if there are no "old" active records
+            #  we need some data to get schema
+            #  so fetch one record from table and overwrite data
+            kn = knackpy.Knack(
+                view=knack_view,
+                scene=knack_scene,
+                app_id=knack_creds['app_id'],
+                page_limit=1,
+                rows_per_page=1
+            )
+
+            kn.data = []
+
+        #  we manually insert field metadata into Knackpy object
+        #  because field metadata is not avaialble in public views
+        #  and we use a public view to reduce the # of private API calls
+        #  of which we have a daily limits
+        kn.fields = TRAFFIC_REPORT_META
+        kn.make_field_map()
+
+        #  get and parse feed
+        feed = feedparser.parse(feed_url)
+        
+        new_records = []
+        for entry in feed.entries:
+            record = {}
+            record[primary_key] = entry.id
+            record[date_field] = entry.published_parsed
+            title = entry.title
+            title = parseTitle(title)
+            record['ADDRESS'] = title[0]
+            record['ISSUE_REPORTED'] = title[1]
+            new_records.append(record)
+
+        #  convert feed fieldnames to Knack database names
+        new_records = datautil.replace_keys(new_records, kn.field_map)
+        primary_key_raw = kn.field_map[primary_key]
+        status_key_raw = kn.field_map[status_key]
+        date_field_raw = kn.field_map[date_field]
+
+        records_archive = []
+        #  look for old records in new data
+        for old_rec in kn.data:
+            if has_match(
+                new_records,
+                old_rec[primary_key_raw],
+                primary_key_raw
+            ):
+                continue
+
+            else:
+                old_rec[status_key_raw] = 'ARCHIVED'
+                records_archive.append(old_rec)
+
+        payload_update = datautil.reduce_to_keys(records_archive, ['id', status_key_raw])
+
+        #  idnentify new records from current feed
+        records_insert = []
+        for new_rec in new_records:
+            if has_match(
+                kn.data,
+                new_rec[primary_key_raw],
+                primary_key_raw
+            ):
+                continue
+
+            else:
+                new_rec[status_key_raw] = 'ACTIVE'
+                records_insert.append(new_rec)
+
+        #  geocode new records
+        payload_insert = []
+        address_field = kn.field_map['ADDRESS']
+        for new_rec in records_insert:
+            geo = agolutil.geocode(geocoder, new_rec[address_field])
+            new_rec = handleGeocode(geo, new_rec, kn.field_map)
+            new_rec[date_field_raw] = handleDateField(new_rec[date_field_raw])
+            payload_insert.append(new_rec)
+        
+        count = 0
+        for record in payload_update:
+            count += 1
+            print( 'Updating record {} of {}'.format( count, len(payload_update) ) )
+            
+            res = knackpy.update_record(
+                record,
+                knack_obj,
+                'id',
+                knack_creds['app_id'],
+                knack_creds['api_key']
+            )
+
+        count = 0
+        for record in payload_insert:
+            count += 1
+            print( 'Inserting record {} of {}'.format( count, len(payload_insert) ) )
+
+            res = knackpy.insert_record(
+                record,
+                knack_obj,
+                knack_creds['app_id'],
+                knack_creds['api_key']
+            )
+
+        return 'Done.'
+
+    except Exception as e:
+        print('Failed to process data for {}'.format(date_time))
+        print(e)
+        emailutil.send_email(ALERTS_DISTRIBUTION, 'Traffic Report Process Failure', str(e), EMAIL['user'], EMAIL['password'])
+        raise e
+
+
+results = main(now)
+logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
+
+print(results)
+
+
+

--- a/shell_scripts/pole_attachments.sh
+++ b/shell_scripts/pole_attachments.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../open_data
+source activate datapub1
+python knack_data_pub.py pole_attachments data_tracker_prod -socrata -agol
+source deactivate

--- a/shell_scripts/traffic_reports.sh
+++ b/shell_scripts/traffic_reports.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../open_data
+source activate datapub1
+python knack_data_pub.py traffic_reports data_tracker_prod -socrata -agol
+source deactivate

--- a/util/agolutil.py
+++ b/util/agolutil.py
@@ -21,6 +21,19 @@ def get_token(creds):
     return token
 
 
+def geocode(url, address):
+    
+    params = {
+        'f' : 'json',
+        'street': address,
+        'outSR' : '4326'
+    }
+
+    res = requests.post(url, params=params)
+    res = res.json()
+    return res
+
+
 def query_all_features(url, token):
     print('Query all features')
     url = url + 'query'

--- a/util/datautil.py
+++ b/util/datautil.py
@@ -44,11 +44,9 @@ def add_missing_keys(dicts, key_vals):
 
     return dicts
 
-
 def unique_keys(dicts):
     keys = [key for record in dicts for key in record]
     return list( set(keys) )
-
 
 def get_key_values(dicts, key):
     #  generate a list of key values from a list of dictionaries
@@ -60,14 +58,11 @@ def lower_case_list(l):
 def lower_case_keys(dicts):
     return [ { k.lower() : v for k,v in record.items() } for record in dicts ]
 
-
 def upper_case_keys(dicts):
     return [ { k.upper() : v for k,v in record.items() } for record in dicts ]
 
-
 def stringify_key_values(dicts):
     return [ { k : str(v).strip() for k,v in record.items() } for record in dicts ] 
-
 
 def remove_linebreaks(dicts, keys):
     print('remove linebreaks')
@@ -84,7 +79,6 @@ def remove_linebreaks(dicts, keys):
         breakless.append(record)
 
     return breakless
-
 
 def mills_to_unix(dicts, keys):
     print('convert millesecond date to unix date')
@@ -103,7 +97,6 @@ def mills_to_unix(dicts, keys):
                         raise ValueError
 
     return dicts
-
 
 def mills_to_iso(dicts, keys, tz='US/Central'):
     print('convert millesecond date to ISO8601 date')
@@ -125,7 +118,6 @@ def mills_to_iso(dicts, keys, tz='US/Central'):
                         raise ValueError
     return dicts
 
-
 def unix_to_mills(dicts):
     print('convert unix dates to milleseconds')
 
@@ -143,7 +135,6 @@ def unix_to_mills(dicts):
                     else:
                         raise ValueError
     return dicts
-
 
 def iso_to_unix(dicts, keys):
     #  requires arrow
@@ -163,7 +154,6 @@ def iso_to_unix(dicts, keys):
                     else:
                         raise ValueError
     return dicts
-
 
 def unix_to_iso(dicts, **options):
     #  requires arrow
@@ -194,7 +184,6 @@ def unix_to_iso(dicts, **options):
 
     return dicts
 
-
 def replaceTimezone(dicts, tz='US/Central', in_format='unix'):
     '''
     replace the timzone of a 'naive' timestamp with its timezone
@@ -216,7 +205,6 @@ def replaceTimezone(dicts, tz='US/Central', in_format='unix'):
                     record[key] = d.replace(tzinfo=tz)
 
     return dicts
-
 
 def merge_dicts(source_dicts, merge_dicts, join_key, merge_keys):
     #  insert specified fields from a merge dictionary to a source dictionary


### PR DESCRIPTION
This new script extracts, transforms, and loads into the Data Tracker "traffic reports" from this feed: http://www.ci.austin.tx.us/qact/qact_rss.cfm. The incidents will separately be published to the Open Data portal and incorporated into operations maps for the Traffic Management Center.