### PR TITLE
ESB CSR Return Messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ tp.py
 script_status.md
 log
 *.log
+xml
 secrets.py

--- a/config/config.py
+++ b/config/config.py
@@ -210,3 +210,20 @@ cfg = {
 }
 
 
+cfg_esb = {
+    'tmc_activities' : {  
+        'obj' : 'object_75',
+        'scene' : 'scene_514',
+        'view' : 'view_1653',
+        'template' : '../config/esb_csr_template.xml',
+        'emi_field' : 'field_1868',
+        'esb_status_field' : 'field_1860',
+        'esb_status_match' : 'READY_TO_SEND',
+        'endpoint' : 'http://esbtest01.austintexas.gov:7888/submitKnack'
+    }
+} 
+
+
+
+
+

--- a/config/esb_csr_template.xml
+++ b/config/esb_csr_template.xml
@@ -1,19 +1,26 @@
-<submitKnack>
-  <header>
-    <emi>{EMI_ID}</emi> <!-- blank -->
-    <timestamp>{PUBLICATION_DATETIME}</timestamp>   <!-- time of publication in unix milliseconds -->
-    <source>KNACK</source> <!--  constant -->
-    <target>CSR</target> <!-- constant -->
-    <data_type>CSR</data_type>  <!-- constant --> 
-    <event>UPDATE</event> <!-- constant -->
-  </header>
-  <data>
-    <csr>
-       <id>{id}</id>
-       <sr_number>{SR_NUMBER}</sr_number>
-       <issue_status_code>{ISSUE_STATUS_CODE}</issue_status_code>
-       <last_activity_details>{LAST_ACTIVITY_DETAILS}</last_activity_details><!--   concatenation of activity type and details -->
-       <last_activity_date>{LAST_ACTIVITY_DATE}</last_activity_date>
-    </csr>
-  </data>
-</submitKnack>
+<soapenv:Envelope
+  xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:acc="http://www.austintexas.gov/AcceptKnack/">
+   <soapenv:Header/>
+    <soapenv:Body>
+      <acc:submitKnack>
+        <header>
+          <emi>{EMI_ID}</emi> <!-- blank -->
+          <timestamp>{PUBLICATION_DATETIME}</timestamp>   <!-- time of publication in unix milliseconds -->
+          <source>KNACK</source> <!--  constant -->
+          <target>CSR</target> <!-- constant -->
+          <data_type>CSR</data_type>  <!-- constant --> 
+          <event>UPDATE</event> <!-- constant -->
+        </header>
+        <data>
+          <csr>
+             <id>{id}</id><!--   tmc activity id -->
+             <sr_number>{SR_NUMBER}</sr_number>
+             <issue_status_code>{ISSUE_STATUS_CODE_SNAPSHOT}</issue_status_code>
+             <activity_details>{TMC_ACTIVITY_DETAILS}</activity_details><!--   concatenation of activity type and details -->
+             <activity_date>{TMC_ACTIVITY_DATETIME}</activity_date>
+          </csr>
+        </data>
+      </acc:submitKnack>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/data_tracker/esb_xml_gen.py
+++ b/data_tracker/esb_xml_gen.py
@@ -1,6 +1,7 @@
-#  update CSR records with status informat from Data Tracker (Knack)
-#  todo:
-#  validation:  ensure only mapped exist values in message
+''' 
+Generate XML message to update 311 Service Reqeusts
+via Enterprise Service Bus
+'''
 import argparse
 import logging
 import pdb
@@ -9,23 +10,72 @@ import arrow
 import knackpy
 
 import _setpath
+from config.config import cfg_esb
 from config.secrets import *
 from util import datautil
 from util import emailutil
 
 
+def get_csr_filters(emi_field, esb_status_field, esb_status_match):
+    #  construct a knack filter object
+    filters = {
+            'match': 'and',
+            'rules': [
+                {
+                   'field': emi_field,
+                   'operator': 'is not blank'
+                },
+                {
+                    'field': esb_status_field,
+                    'operator': 'is',
+                    'value': esb_status_match
+                }
+            ]
+        };
+
+    return filters
+
+
+def check_for_data():
+    #  check for data at public endpoint
+    #  this api call does not count against
+    #  daily subscription limit
+    kn = knackpy.Knack(
+        view=cfg['view'],
+        scene=cfg['scene'],
+        app_id=KNACK_CREDENTIALS[app_name]['app_id'],
+        api_key='knack',
+        page_limit=1,
+        rows_per_page=1
+    )
+    
+    if kn.data_raw:
+        return True
+    else:
+        return False
+
+
+def get_data(filters):
+    return knackpy.Knack(
+        obj=cfg['obj'],
+        app_id=KNACK_CREDENTIALS[app_name]['app_id'],
+        api_key=KNACK_CREDENTIALS[app_name]['api_key'],
+        filters=filters
+    )
+
+
 def build_xml_payload(record):
-    record['LAST_ACTIVITY_DETAILS'] = format_activity_details(record)
+    record['TMC_ACTIVITY_DETAILS'] = format_activity_details(record)
     record['PUBLICATION_DATETIME'] = arrow.now().format()
 
-    with open(template_path, 'r') as fin:
+    with open(cfg['template'], 'r') as fin:
         template = fin.read()
         return template.format(**record)
 
 
 def format_activity_details(record):
-    activity = record['LAST_ACTIVITY']
-    details = record['LAST_ACTIVITY_DETAILS']
+    activity = record['TMC_ACTIVITY']
+    details = record['TMC_ACTIVITY_DETAILS']
 
     if activity and details:
         return '{} - {}'.format(activity, details)
@@ -57,15 +107,15 @@ def main(date_time):
     print('starting stuff now')
 
     try:
-        kn = knackpy.Knack(
-            view=view,
-            scene=scene,
-            ref_obj=[obj],
-            app_id=KNACK_CREDENTIALS[app_name]['app_id'],
-            api_key=KNACK_CREDENTIALS[app_name]['api_key']
-        )
+        data = check_for_data()
 
-        if not kn.data:
+        #  check for data at public endpoint
+        if data:
+            #  get data at private enpoint
+            filters = get_csr_filters(cfg['emi_field'], cfg['esb_status_field'], cfg['esb_status_match'])
+            kn = get_data(filters)
+            
+        else:
             logging.info('No new records to process')
             return None
 
@@ -80,7 +130,7 @@ def main(date_time):
             payload = payload.encode("ascii", errors="ignore")
             payload = payload.decode("ascii")
             
-            with open('{}/{}.xml'.format(outpath, record['id']), 'w') as fout:
+            with open('{}/{}_{}.xml'.format(outpath, record['id'], arrow.now().timestamp), 'w') as fout:
                 fout.write(payload)
             
         return 'GOOD JOB!'
@@ -89,16 +139,15 @@ def main(date_time):
         print('Failed to process data for {}'.format(date_time))
         print(e)
         
-        # emailutil.send_email(
-        #     ALERTS_DISTRIBUTION,
-        #     'Location Update Failure',
-        #     str(e),
-        #     EMAIL['user'],
-        #     EMAIL['password']
-        # )
+        emailutil.send_email(
+            ALERTS_DISTRIBUTION,
+            'Location Update Failure',
+            str(e),
+            EMAIL['user'],
+            EMAIL['password']
+        )
 
         raise e
-
 
 if __name__ == '__main__':
     args = cli_args()
@@ -108,23 +157,17 @@ if __name__ == '__main__':
     now_s = now.format('YYYY_MM_DD')
 
     #  init logging 
-    logfile = '{}/csr_updater_{}.log'.format(LOG_DIRECTORY, now_s)
+    logfile = '{}/esb_xml_gen_{}.log'.format(LOG_DIRECTORY, now_s)
     logging.basicConfig(filename=logfile, level=logging.INFO)
     logging.info('START AT {}'.format(str(now)))
 
     #  config
     knack_creds = KNACK_CREDENTIALS
-    obj = 'object_83'
-    view = 'view_1445'
-    scene = 'scene_514'
-    template_path = '../config/esb_csr_template.xml'
+    cfg = cfg_esb['tmc_activities']
     
     #  template output path
-    outpath = '{}/xml'.format(LOG_DIRECTORY)
+    outpath = '{}/{}'.format(ESB_XML_DIRECTORY, 'ready_to_send')
 
     results = main(now)
     logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
-
-
-
 

--- a/data_tracker/esb_xml_send.py
+++ b/data_tracker/esb_xml_send.py
@@ -1,0 +1,150 @@
+''' 
+Generate XML message to update 311 Service Reqeusts
+via Enterprise Service Bus
+
+todo:
+- define ESB_LOG_DIRECTORY and update secrets
+- email alerts
+'''
+import argparse
+import logging
+import os
+import pdb
+
+import arrow
+import knackpy
+import requests
+
+import _setpath
+from config.config import cfg_esb
+from config.secrets import *
+from util import datautil
+from util import emailutil
+
+  
+def get_record_id_from_file(directory, f):
+    record_id = f.split('_')[0]
+    return record_id
+
+def get_msg(directory, f):
+    #  read xml msg memory
+    fin = os.path.join(directory, f)
+    with open(fin, 'r') as msg:
+        return msg.read()
+
+def send_msg(msg, endpoint, timeout=20):
+    headers = {'content-type': 'text/xml'}
+    res = requests.post(endpoint, data=msg, headers=headers, timeout=timeout)
+    return res
+
+def move_file(old_dir, new_dir, f):
+    infile = os.path.join(old_dir, f)
+    outfile = os.path.join(new_dir, f)
+    os.rename(infile, outfile)
+
+
+def create_payload(record):
+    payload = {
+        'id' : record,
+        cfg['esb_status_field'] : 'SENT'
+    }
+    return payload
+
+
+def cli_args():
+    parser = argparse.ArgumentParser(
+        prog='csr updater',
+        description='Update service requests in the CSR system from Data Tracker'
+    )
+
+    parser.add_argument(
+        'app_name',
+        action="store",
+        type=str,
+        help='Name of the knack application that will be accessed'
+    )
+
+    args = parser.parse_args()
+    
+    return(args)
+
+
+def main(date_time):
+    print('starting stuff now')
+
+    try:
+        directory = os.fsencode(inpath)
+
+        sent = []
+        fail = []
+        for file in os.listdir(inpath):
+            filename = os.fsdecode(file)
+            
+            if filename.endswith(".xml"): 
+                record_id = get_record_id_from_file(inpath, filename)
+                msg = get_msg(inpath, filename)
+                res = send_msg(msg, cfg['endpoint'])
+                
+                if res.status_code == 200:
+                    sent.append(record_id)
+                    move_file(inpath, outpath, filename)
+                else: 
+                    logging.warning( 'Record {} failed to process with error {}'.format(record_id, res.content) ) 
+                    fail.append(res.content)
+
+        for record in sent:
+            payload = create_payload(record)
+            
+            res = knackpy.update_record(
+                payload,
+                cfg['obj'],  #  assumes record object is included in config ref_obj and is the first elem in array
+                'id',
+                knack_creds['app_id'],
+                knack_creds['api_key']
+            )
+            
+        #  send email at end if issues
+        if fail:
+            raise Exception('Records failed to publish to ESB. See log for more details.')
+
+        logging.info('{} records transmitted.'.format(len(sent)))
+        
+
+    except Exception as e:
+        print('Failed to publish ESB msg data for {}'.format(date_time))
+        print(e)
+        
+        # emailutil.send_email(
+        #     ALERTS_DISTRIBUTION,
+        #     'ESB Publication Failure',
+        #     str(e),
+        #     EMAIL['user'],
+        #     EMAIL['password']
+        # )
+
+        raise e
+
+if __name__ == '__main__':
+    args = cli_args()
+    app_name = args.app_name
+
+    now = arrow.now()
+    now_s = now.format('YYYY_MM_DD')
+
+    #  init logging 
+    logfile = '{}/esb_xml_send_{}.log'.format(LOG_DIRECTORY, now_s)
+    logging.basicConfig(filename=logfile, level=logging.INFO)
+    logging.info('START AT {}'.format(str(now)))
+
+    #  config
+    knack_creds = KNACK_CREDENTIALS[app_name]
+    cfg = cfg_esb['tmc_activities']
+    
+    #  template output path
+    inpath = '{}/{}'.format(ESB_XML_DIRECTORY, 'ready_to_send')
+    outpath = '{}/{}'.format(ESB_XML_DIRECTORY, 'sent')
+
+    results = main(now)
+    logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
+
+

--- a/shell_scripts/esb_xml_gen.sh
+++ b/shell_scripts/esb_xml_gen.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python esb_xml_gen.py data_tracker_prod
+source deactivate

--- a/shell_scripts/esb_xml_send.sh
+++ b/shell_scripts/esb_xml_send.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python esb_xml_send.py data_tracker_prod
+source deactivate


### PR DESCRIPTION
This commit adds new scripts and configs to enable automated processing of service requests acitivites in the Data Tracker. The scripts poll the data tracker for activities carried out in response to service requests, and send those activities to the Enterprise Service Bus to be passed on to the CSR 311 system. Once deployed, these scripts will complete our integration with the 311 CSR system, allowing Arterial Management staff --including the Traffic Management Center-- to manage 311 service requests entirely in the Data Tracker.