### PR TITLE
Publish Signal Requests to ArcGIS Online

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -26,6 +26,19 @@ cfg = {
             'lon' : 'LOCATION_longitude'
         }
     },
+    'signal_requests' : {
+        'primary_key' : 'REQUEST_ID',
+        'obj' : None,
+        'scene' : 'scene_75',
+        'view' : 'view_200',
+        'ref_obj' : ['object_11', 'object_13'],
+        'service_url' : 'http://services.arcgis.com/0L95CJ0VTaxqcmED/arcgis/rest/services/TRANSPORTATION_signal_requests/FeatureServer/0/',
+        'include_ids' : True,
+        'location_fields' : {
+            'lat' : 'LOCATION_latitude',
+            'lon' : 'LOCATION_longitude'
+        }
+    },
     'cameras' : {
         'primary_key' : 'CAMERA_ID',
         'ref_obj' : ['object_53', 'object_11'],

--- a/open_data/knack_data_pub.py
+++ b/open_data/knack_data_pub.py
@@ -105,7 +105,6 @@ def main(date_time):
                 agol_fail += 1
                 
                 if agol_fail == 1:
-                    pdb.set_trace()
                     #  alert on first failure, but continue processing
                     emailutil.send_email(
                         ALERTS_DISTRIBUTION,

--- a/shell_scripts/signal_requests.sh
+++ b/shell_scripts/signal_requests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../open_data
+source activate datapub1
+python knack_data_pub.py signal_requests data_tracker_prod -agol
+source deactivate


### PR DESCRIPTION
This commit provides config and shell scripts for publishign traffic and pedestrian signal requests to ArcGIS Online. Although we have been publishing signal request evaluations, we were not publishing any data at the signal request level.