### PR TITLE
KITS CCTV Push Shell Script

### DIFF
--- a/shell_scripts/kits_cctv_push.sh
+++ b/shell_scripts/kits_cctv_push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python kits_cctv_push.py
+source deactivate


### PR DESCRIPTION
This commit creates a shell script to fire off kits_cctv_push.py. The script was developed and deployed on the VM months ago, but was not tracked by the repo. That's fixed now.