### PR TITLE
Shell Script Updates

### DIFF
--- a/data_tracker/secondary_signals_updater.py
+++ b/data_tracker/secondary_signals_updater.py
@@ -110,10 +110,9 @@ def main(date_time):
             identify new and changed primary-secondary relationships
             '''
             if signal_id in primary_signals_old:
-                
                 new_secondaries = collections.Counter(primary_signals_new[signal_id])
                 old_secondaries = collections.Counter(primary_signals_old[signal_id])
-    
+                
                 if old_secondaries != new_secondaries:
                     
                     payload.append({

--- a/shell_scripts/kits_cctv_push.sh
+++ b/shell_scripts/kits_cctv_push.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python kits_cctv_push.py
+source deactivate

--- a/shell_scripts/secondary_signals_updater.sh
+++ b/shell_scripts/secondary_signals_updater.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd ../data_tracker
 source activate datapub1
-python secondary_signals_updater.py
+python secondary_signals_updater.py data_tracker_prod
 source deactivate


### PR DESCRIPTION
This commit creates a shell script to fire off kits_cctv_push.py. The script was developed and deployed on the VM months ago, but was not tracked by the repo. That's fixed now.

This commit also updates the secondary_signals_updater shell script, which was missing the app_name paramater. It's been updated to point to the production system.