### PR TITLE
Create Socrata Location Fields Properly

### DIFF
--- a/open_data/sig_stat_pub.py
+++ b/open_data/sig_stat_pub.py
@@ -164,7 +164,9 @@ def main(date_time):
             )
 
             socrata_payload = socratautil.create_location_fields(
-                socrata_payload
+                socrata_payload,
+                lat_field='LOCATION_LATITUDE',
+                lon_field='LOCATION_LONGITUDE'
             )
 
             socrata_payload = datautil.lower_case_keys(

--- a/util/socratautil.py
+++ b/util/socratautil.py
@@ -136,14 +136,18 @@ def create_location_fields(
     lon_field='LOCATION_longitude'
 ):
     
-
     for record in dicts:
+        #  create location field if lat and lon are avaialble
         if lat_field in record and lon_field in record:
             
             record['location'] = '({},{})'.format(
                 record[lat_field],
                 record[lon_field]
             )
+
+        else:
+            #  otherwise create empty location field
+            record['location'] = ''
 
     return dicts
 


### PR DESCRIPTION
This fix ensures that socrata location field is properly formatted on signal status payload by passing the correct lat and lon field names to the create_location_field function.