### PR TITLE
Verify Socrata Requests

### DIFF
--- a/util/socratautil.py
+++ b/util/socratautil.py
@@ -58,7 +58,7 @@ class Soda(object):
 
     def get_public_data(self):
         print('fetch public socrata data')
-        res = requests.get(self.url, verify=False)
+        res = requests.get(self.url)
         self.data = res.json()
         return self.data
 
@@ -72,8 +72,7 @@ class Soda(object):
         
         res = requests.get(
             self.url,
-            auth=auth,
-            verify=False
+            auth=auth
         )
 
         return res.json()
@@ -88,8 +87,7 @@ class Soda(object):
         
         res = requests.get(
             self.url_metadata,
-            auth=auth,
-            verify=False
+            auth=auth
         )
         
         self.metadata = res.json()
@@ -171,8 +169,7 @@ def upsert_data(creds, payload, resource):
     res = requests.post(
         url,
         data=json_data,
-        auth=auth,
-        verify=False
+        auth=auth
     )
     
     return res.json()


### PR DESCRIPTION
When we first started using the Socrata API, I was experiencing some weirdness where requests were routing to a different entity's data portal (I think it was City of Cincinnati). It was probably some  mistake on my end, but it also kinda seemed like a Socrata bug. The easiest solution at the time was to use Requests verify=false option, which was obviously not ideal.

After retesting without verify=false, it seems the re-routing issue is no longer an issue. So this commit removes verify=false from all of our Socrata requests and makes us sleep a lil better at night.