### PR TITLE
Fixes for Device Status Check Deploy

### DIFF
--- a/data_tracker/device_status.py
+++ b/data_tracker/device_status.py
@@ -1,8 +1,5 @@
 '''
 todo:
-- test updaterecord
-- check ip comm status datetime
-- test ping command
 - enable email alert
 ping field device and update ip comm status in Knack database
 command ex: device_status_check.py travel_sensors
@@ -10,8 +7,9 @@ command ex: device_status_check.py travel_sensors
 import argparse
 import json
 import logging
-import os
+from os import system as system_call
 import pdb
+from platform import system as system_name  
 import traceback
 
 import arrow
@@ -24,15 +22,20 @@ from util import datautil
 from util import emailutil
 
 def ping_ip(ip):
+    #  https://stackoverflow.com/questions/2953462/pinging-servers-in-python
     print(ip)
     logging.debug( 'ping {}'.format(ip) )
-    response = os.system("ping -n 1 -w 1000 " + ip)
+        
+    #  logic for system-specific param
+    #  -w / -W is timeout -n/-c is number of packets
+    params= "-w 1000 -n 1" if system_name().lower()=="windows" else "-W 1 -c 1"    
+
+    response = system_call("ping " + params + " " + ip)
+
     logging.debug(str(response))
 
     if response != 0:
-        logging.warning( 'no response from {}'.format(ip) )
         return "OFFLINE"
-
     else:
         return "ONLINE"
 

--- a/shell_scripts/device_status_cameras.sh
+++ b/shell_scripts/device_status_cameras.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python device_status.py cameras data_tracker_prod -json
+source deactivate

--- a/shell_scripts/device_status_detectors.sh
+++ b/shell_scripts/device_status_detectors.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python device_status.py detectors data_tracker_prod
+source deactivate

--- a/shell_scripts/device_status_signals.sh
+++ b/shell_scripts/device_status_signals.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python device_status.py signals data_tracker_prod
+source deactivate

--- a/shell_scripts/device_status_travel_sensors.sh
+++ b/shell_scripts/device_status_travel_sensors.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python device_status.py travel_sensors data_tracker_prod
+source deactivate


### PR DESCRIPTION
Our scripting server (finally) has communications to the traffic signal network, so we're ready to deploy the nightly device status check scripts. To that end, this commit adds cross-platform support for pinging (the param flags are slightly different in windows vs linux/osx) and adds the shell scripts that will be deployed via cron.