### PR TITLE
Handle Multiple Intersect Features on Point in Poly

### DIFF
--- a/data_tracker/location_updater.py
+++ b/data_tracker/location_updater.py
@@ -13,6 +13,28 @@ from util import datautil
 from util import emailutil
 
 
+def get_params(layer_config):
+
+    params = {
+        'f' : 'json',
+        'outFields'  : '*',
+        'geometry': None,
+        'geomtryType' : 'esriGeometryPoint',
+        'returnGeometry' : False,
+        'spatialRel' :'esriSpatialRelIntersects',
+        'inSR' : 4326,
+        'geometryType' : 'esriGeometryPoint',
+        'distance' : None,
+        'units' : None
+    }
+
+    for param in layer_config:
+        if param in params:
+            params[param] = layer_config[param]
+
+    return params
+    
+    
 def cli_args():
     parser = argparse.ArgumentParser(
         prog='knack_data_pub.py',
@@ -31,6 +53,31 @@ def cli_args():
     return(args)
 
 
+def handleFeatures(features, layer_config, location):
+    handler = layer_config['handle_features']
+    if handler == 'use_first' or len(features) == 1:
+        #  use first feature in results and join feature data to location record
+        feature = features[0]
+        for field in feature['attributes'].keys():
+            #  remove whitespace from janky Esri fields
+            try:
+                location[field] = str(feature['attributes'][field]).strip()
+            except KeyError:
+                continue
+
+    elif handler == 'merge_all' and len(features) > 1:
+        #  concatenate feature data from all retrieved features 
+        #  and join to location record
+        for feature in features:
+            for field in feature['attributes'].keys():
+                if field not in location:
+                    location[field] = []
+                    
+                location[field].append(str(feature['attributes'][field]).strip())
+
+    return location
+
+
 def main(date_time):
     print('starting stuff now')
 
@@ -39,7 +86,8 @@ def main(date_time):
             obj=obj,
             app_id=KNACK_CREDENTIALS[app_name]['app_id'],
             api_key=KNACK_CREDENTIALS[app_name]['api_key'],
-            filters=filters
+            filters=filters,
+            timeout=30
         )
 
         update_response = []
@@ -51,8 +99,11 @@ def main(date_time):
             logging.info('No new records to process')
             return None
 
+        keep_fields = [field for field in kn.fieldnames if field not in outfields]
+        kn.data = datautil.reduce_to_keys(kn.data, keep_fields)
+        total = len(kn.data)
         for location in kn.data:
-            
+            print('Processing {} of {}'.format(count, total))
             count += 1
 
             point = [ 
@@ -61,30 +112,39 @@ def main(date_time):
             ]
 
             for layer in layers:
+                layer['geometry'] = point
+
+                params = get_params(layer)
+
                 try:
-                    intersect = agolutil.point_in_poly(
+                    res = agolutil.point_in_poly(
                         layer['service_name'],
                         layer['layer_id'],
-                        point,
-                        layer['outfields']
-                    )
+                        params
+                    )                    
+                
                     
-                    for field in layer['outfields']:
-                        if field in intersect:
-                            try:
-                                #  remove whitespace from janky Esri fields
-                                intersect[field] = intersect[field].strip()
-                            except AttributeError:
-                                pass
+                    if len(res['features']) > 0:
+                        location = handleFeatures(res['features'], layer, location)
+                        continue
 
-                            location[field] = intersect[field]
+                    else:
+                        #  no intersecting features found
+                        #  set outfields to null to overwrite any existing data
+                        for field in outfields:
+                            if field in layer['outFields']:
+                                location[field] = ''
+
+                        logging.info(location)
+                        continue
 
                 except Exception as e:
                     unmatched_locations.append(location)
                     print("Unable to retrieve segment {}".format(location))
-
+                    raise e
+            
             location['UPDATE_PROCESSED'] = True
-            location = datautil.reduce_to_keys([location], outfields)
+            location = datautil.reduce_to_keys([location], outfields + ['id'])
             location = datautil.replace_keys(location, kn.field_map)
             
             response_json = knackpy.update_record(
@@ -94,11 +154,10 @@ def main(date_time):
                 KNACK_CREDENTIALS[app_name]['app_id'],
                 KNACK_CREDENTIALS[app_name]['api_key']
             )
-
+            
             update_response.append(response_json)
 
         if (len(unmatched_locations) > 0):
-            
             emailutil.send_email(
                 ALERTS_DISTRIBUTION,
                 'Location Point/Poly Match Failure',
@@ -144,25 +203,30 @@ if __name__ == '__main__':
         'JURISDICTION_LABEL',
         'SIGNAL_ENG_AREA',
         'COUNCIL_DISTRICT',
-        'UPDATE_PROCESSED',
-        'id'
+        'UPDATE_PROCESSED'
     ]
 
     layers = [
         {
             'service_name' : 'BOUNDARIES_single_member_districts',
-            'outfields' : ['COUNCIL_DISTRICT'],
-            'layer_id' : 0
+            'outFields' : 'COUNCIL_DISTRICT',
+            'layer_id' : 0,
+            'distance' : 100,
+            'units' : 'esriSRUnit_Foot',
+            #  how to handle query that returns multiple intersection features
+            'handle_features' : 'merge_all'  
         },
         {
             'service_name' : 'BOUNDARIES_jurisdictions',
-            'outfields' : ['JURISDICTION_LABEL'],
-            'layer_id' : 0
+            'outFields' : 'JURISDICTION_LABEL',
+            'layer_id' : 0,
+            'handle_features' : 'use_first'
         },
         {
             'service_name' : 'ATD_signal_engineer_areas',
-            'outfields' : ['SIGNAL_ENG_AREA'],
-            'layer_id' : 0
+            'outFields' : 'SIGNAL_ENG_AREA',
+            'layer_id' : 0,
+            'handle_features' : 'use_first'
         }
     ]
 

--- a/util/agolutil.py
+++ b/util/agolutil.py
@@ -186,38 +186,23 @@ def query_atx_street(segment_id):
         return None
 
 
-def point_in_poly(service_name, layer_id, point_geom, outfields):
-    #  check if point is within polygon feature
-    #  return attributes of containing feature 
-    #  assume input geometry spatial reference is WGS84
+def point_in_poly(service_name, layer_id, params):
+    '''
+    check if point is within polygon feature
+    return attributes of containing feature 
+    assume input geometry spatial reference is WGS84
+    docs: http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r3000000p1000000
+    '''
     print('Point in poly: {}'.format(service_name))
-    point = '{},{}'.format(point_geom[0],point_geom[1]) 
     
-    outfields = ','.join( str(e) for e in outfields )
     query_url = 'http://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/{}/FeatureServer/{}/query'.format(service_name, layer_id)
-    params = {
-        'f' : 'json',
-        'outFields'  : outfields,
-        'geometry': point,
-        'returnGeometry' : False,
-        'spatialRel' :'esriSpatialRelIntersects',
-        'inSR' : 4326,
-        'geometryType' : 'esriGeometryPoint'
-    }
     
+    if 'spatialRel' not in params:
+        params['spatialRel'] = 'esriSpatialRelIntersects'
+
     res = requests.get(query_url, params=params)
-
     res = res.json()
-
-    if 'features' in res:
-        if len(res['features']) > 0:
-            return res['features'][0]['attributes']
-
-        else:
-            return ''
-
-    else:
-        raise ValueError('point in poly request failure')
+    return res
 
 
 def parse_response(res_msg, req_type):


### PR DESCRIPTION
This commit adds support for retrieving multiple features from an AGOL feature service by passing a search distance and units to the point_in_poly utility.

We've also updated the location_updater.py to use the functionality and parse the mutiple feature objects that this method returns. This allows us to properly identify locations which lie on the border of multiple council districts.