### PR TITLE
Handle Multiple Intersect Features on Point in Poly

### DIFF
--- a/data_tracker/location_updater.py
+++ b/data_tracker/location_updater.py
@@ -1,4 +1,7 @@
-#  update Knack street segments with data from COA ArcGIS Online Feature Service
+'''
+Update Data Tracker location records with council district, engineer area,
+and jurisdiction attributes from from COA ArcGIS Online feature services
+'''
 import argparse
 import logging
 import pdb
@@ -11,6 +14,83 @@ from config.secrets import *
 from util import agolutil
 from util import datautil
 from util import emailutil
+
+
+#  config
+knack_creds = KNACK_CREDENTIALS
+obj = 'object_11'
+
+update_fields = [
+    'JURISDICTION_LABEL',
+    'SIGNAL_ENG_AREA',
+    'COUNCIL_DISTRICT',
+    'UPDATE_PROCESSED'
+]
+
+'''
+layer config for interacting with ArcGIS Online
+see: http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r3000000p1000000
+'''
+layers = [
+    {   
+        'service_name' : 'BOUNDARIES_single_member_districts',
+        'outFields' : 'COUNCIL_DISTRICT',
+        'layer_id' : 0,
+        'distance' : 100,
+        'units' : 'esriSRUnit_Foot',
+        #  how to handle query that returns multiple intersection features
+        'handle_features' : 'merge_all'  
+    },
+    {
+        'service_name' : 'BOUNDARIES_jurisdictions',
+        #  will attempt secondary attempt secondary service if no results at primary 
+        'service_name_secondary' : 'BOUNDARIES_jurisdictions_planning',
+        'outFields' : 'JURISDICTION_LABEL',
+        'layer_id' : 0,
+        'handle_features' : 'use_first'
+    },
+    {
+        'service_name' : 'ATD_signal_engineer_areas',
+        'outFields' : 'SIGNAL_ENG_AREA',
+        'layer_id' : 0,
+        'handle_features' : 'use_first'
+    }
+]
+
+filters = {
+    #  filter for records where
+    #  UPDATE_PROCESSED field is No
+    'match': 'and',
+    'rules': [
+        {
+           'field':'field_1357',
+           'operator':'is',
+           'value':'No'
+        }
+    ]
+}
+
+
+def get_params(layer_config):
+    '''base params for AGOL query request'''
+    params = {
+        'f' : 'json',
+        'outFields'  : '*',
+        'geometry': None,
+        'geomtryType' : 'esriGeometryPoint',
+        'returnGeometry' : False,
+        'spatialRel' :'esriSpatialRelIntersects',
+        'inSR' : 4326,
+        'geometryType' : 'esriGeometryPoint',
+        'distance' : None,
+        'units' : None
+    }
+
+    for param in layer_config:
+        if param in params:
+            params[param] = layer_config[param]
+
+    return params
 
 
 def cli_args():
@@ -31,6 +111,50 @@ def cli_args():
     return(args)
 
 
+
+def join_features_to_record(features, layer_config, record):
+    ''''
+    Join feature attributes from ArcGIS Online query to location record
+    
+    Parameters
+    ----------
+    features : list (required)
+        The 'features' array from an Esri query response object.
+        See see: http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r3000000p1000000
+    layer_config : dict (required)
+        The layer configuration dict that was provided to the ArcGIS Online query 
+        and returned the providded features.
+    record : dict (required)
+        The source database record whose geomtetry intersects with
+        the provided features
+
+    Returns
+    -------
+    record (dict)
+        The updated record object with location attributes attached
+    '''
+    handler = layer_config['handle_features']
+
+    if handler == 'use_first' or len(features) == 1:
+        #  use first feature in results and join feature data to location record
+        feature = features[0]
+
+        for field in feature['attributes'].keys():
+            #  remove whitespace from janky Esri fields
+            record[field] = str(feature['attributes'][field]).strip()
+
+    elif handler == 'merge_all' and len(features) > 1:
+        #  concatenate feature attributes from each feature and join to record
+        for feature in features:
+            for field in feature['attributes'].keys():
+                if field not in record:
+                    record[field] = []
+                    
+                record[field].append(str(feature['attributes'][field]).strip())
+
+    return record
+
+
 def main(date_time):
     print('starting stuff now')
 
@@ -39,20 +163,22 @@ def main(date_time):
             obj=obj,
             app_id=KNACK_CREDENTIALS[app_name]['app_id'],
             api_key=KNACK_CREDENTIALS[app_name]['api_key'],
-            filters=filters
+            filters=filters,
+            timeout=30
         )
 
         update_response = []
         unmatched_locations = []
-
         count = 0
 
         if not kn.data:
             logging.info('No new records to process')
             return None
 
+        keep_fields = [field for field in kn.fieldnames if field not in update_fields]
+        kn.data = datautil.reduce_to_keys(kn.data, keep_fields)
+        
         for location in kn.data:
-            
             count += 1
 
             point = [ 
@@ -61,30 +187,52 @@ def main(date_time):
             ]
 
             for layer in layers:
+                layer['geometry'] = point
+
+                params = get_params(layer)
+
                 try:
-                    intersect = agolutil.point_in_poly(
+                    res = agolutil.point_in_poly(
                         layer['service_name'],
                         layer['layer_id'],
-                        point,
-                        layer['outfields']
-                    )
-                    
-                    for field in layer['outfields']:
-                        if field in intersect:
-                            try:
-                                #  remove whitespace from janky Esri fields
-                                intersect[field] = intersect[field].strip()
-                            except AttributeError:
-                                pass
+                        params
+                    )                    
+                                
+                    if len(res['features']) > 0:
+                        location = join_features_to_record(res['features'], layer, location)
+                        continue
 
-                            location[field] = intersect[field]
+                    if 'service_name_secondary' in layer:
+                        '''
+                        look for features at secondary service, if specified
+                        '''
+                        res = agolutil.point_in_poly(
+                            layer['service_name_secondary'],
+                            layer['layer_id'],
+                            params
+                        )
+
+                        if len(res['features']) > 0:
+                            location = join_features_to_record(res['features'], layer, location)
+                            continue
+                       
+                    '''
+                    no intersecting features found.
+                    set update fields to null to overwrite any existing data
+                    '''
+                    for field in update_fields:
+                        if field in layer['outFields']:
+                            location[field] = ''
+
+                    continue
 
                 except Exception as e:
                     unmatched_locations.append(location)
                     print("Unable to retrieve segment {}".format(location))
-
+                    raise e
+            
             location['UPDATE_PROCESSED'] = True
-            location = datautil.reduce_to_keys([location], outfields)
+            location = datautil.reduce_to_keys([location], update_fields + ['id'])
             location = datautil.replace_keys(location, kn.field_map)
             
             response_json = knackpy.update_record(
@@ -94,11 +242,10 @@ def main(date_time):
                 KNACK_CREDENTIALS[app_name]['app_id'],
                 KNACK_CREDENTIALS[app_name]['api_key']
             )
-
+            
             update_response.append(response_json)
 
         if (len(unmatched_locations) > 0):
-            
             emailutil.send_email(
                 ALERTS_DISTRIBUTION,
                 'Location Point/Poly Match Failure',
@@ -135,49 +282,6 @@ if __name__ == '__main__':
     logfile = '{}/location_updater_{}.log'.format(LOG_DIRECTORY, now_s)
     logging.basicConfig(filename=logfile, level=logging.INFO)
     logging.info('START AT {}'.format(str(now)))
-
-    #  config
-    knack_creds = KNACK_CREDENTIALS
-    obj = 'object_11'
-
-    outfields = [
-        'JURISDICTION_LABEL',
-        'SIGNAL_ENG_AREA',
-        'COUNCIL_DISTRICT',
-        'UPDATE_PROCESSED',
-        'id'
-    ]
-
-    layers = [
-        {
-            'service_name' : 'BOUNDARIES_single_member_districts',
-            'outfields' : ['COUNCIL_DISTRICT'],
-            'layer_id' : 0
-        },
-        {
-            'service_name' : 'BOUNDARIES_jurisdictions',
-            'outfields' : ['JURISDICTION_LABEL'],
-            'layer_id' : 0
-        },
-        {
-            'service_name' : 'ATD_signal_engineer_areas',
-            'outfields' : ['SIGNAL_ENG_AREA'],
-            'layer_id' : 0
-        }
-    ]
-
-    filters = {
-        #  filter for records where
-        #  UPDATE_PROCESSED field is No
-        'match': 'and',
-        'rules': [
-            {
-               'field':'field_1357',
-               'operator':'is',
-               'value':'No'
-            }
-        ]
-    }
 
     results = main(now)
     logging.info('END AT {}'.format(str( arrow.now().timestamp) ))

--- a/util/agolutil.py
+++ b/util/agolutil.py
@@ -186,38 +186,23 @@ def query_atx_street(segment_id):
         return None
 
 
-def point_in_poly(service_name, layer_id, point_geom, outfields):
-    #  check if point is within polygon feature
-    #  return attributes of containing feature 
-    #  assume input geometry spatial reference is WGS84
+def point_in_poly(service_name, layer_id, params):
+    '''
+    check if point is within polygon feature
+    return attributes of containing feature 
+    assume input geometry spatial reference is WGS84
+    docs: http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#//02r3000000p1000000
+    '''
     print('Point in poly: {}'.format(service_name))
-    point = '{},{}'.format(point_geom[0],point_geom[1]) 
     
-    outfields = ','.join( str(e) for e in outfields )
     query_url = 'http://services.arcgis.com/0L95CJ0VTaxqcmED/ArcGIS/rest/services/{}/FeatureServer/{}/query'.format(service_name, layer_id)
-    params = {
-        'f' : 'json',
-        'outFields'  : outfields,
-        'geometry': point,
-        'returnGeometry' : False,
-        'spatialRel' :'esriSpatialRelIntersects',
-        'inSR' : 4326,
-        'geometryType' : 'esriGeometryPoint'
-    }
     
+    if 'spatialRel' not in params:
+        params['spatialRel'] = 'esriSpatialRelIntersects'
+
     res = requests.get(query_url, params=params)
-
     res = res.json()
-
-    if 'features' in res:
-        if len(res['features']) > 0:
-            return res['features'][0]['attributes']
-
-        else:
-            return ''
-
-    else:
-        raise ValueError('point in poly request failure')
+    return res
 
 
 def parse_response(res_msg, req_type):


### PR DESCRIPTION
This commit adds support for retrieving multiple features from an AGOL feature service by passing a search distance and units to the point_in_poly utility.

We've also updated the location_updater.py to use the functionality and parse the mutiple feature objects that this method returns. This allows us to properly identify locations which lie on the border of multiple council districts.