### PR TITLE
Upgrade to Knackpy 0.0.5

### DIFF
--- a/data_tracker/detection_status_signals.py
+++ b/data_tracker/detection_status_signals.py
@@ -240,7 +240,6 @@ if __name__ == '__main__':
             res = knackpy.update_record(
                 payload_signals[0],
                 config_signals['objects'][0],
-                'id',
                 app_id,
                 api_key
             )

--- a/data_tracker/device_status.py
+++ b/data_tracker/device_status.py
@@ -92,7 +92,6 @@ def main():
                     response_json = knackpy.update_record(
                             device[0],  #  convert device from array len 1 to dict
                             cfg[device_type]['ref_obj'][0],  #  assumes record object is included in config ref_obj and is the first elem in array
-                            'id',
                             knack_creds['app_id'],
                             knack_creds['api_key']
                     )

--- a/data_tracker/esb_xml_send.py
+++ b/data_tracker/esb_xml_send.py
@@ -108,7 +108,6 @@ def main(date_time):
             res = knackpy.update_record(
                 payload,
                 cfg['obj'],
-                'id',
                 knack_creds['app_id'],
                 knack_creds['api_key']
             )

--- a/data_tracker/location_updater.py
+++ b/data_tracker/location_updater.py
@@ -238,11 +238,10 @@ def main(date_time):
             response_json = knackpy.update_record(
                 location[0],
                 obj,
-                'id',
                 KNACK_CREDENTIALS[app_name]['app_id'],
                 KNACK_CREDENTIALS[app_name]['api_key']
             )
-            
+
             update_response.append(response_json)
 
         if (len(unmatched_locations) > 0):

--- a/data_tracker/secondary_signals_updater.py
+++ b/data_tracker/secondary_signals_updater.py
@@ -148,8 +148,9 @@ def main(date_time):
             print( 'updating record {} of {}'.format( count, len(payload) ) )
         
             response_json = knackpy.update_record(
-                record, ref_obj[0], 
-                'id', knack_creds['app_id'],
+                record,
+                ref_obj[0], 
+                knack_creds['app_id'],
                 knack_creds['api_key']
             )
 

--- a/data_tracker/signal_pm_copier.py
+++ b/data_tracker/signal_pm_copier.py
@@ -157,7 +157,6 @@ def main(date_time):
             response_json = knackpy.update_record(
                 record,
                 params_pm['field_obj'][0],
-                'id',
                 knack_creds['app_id'],
                 knack_creds['api_key']
             )

--- a/data_tracker/signal_request_ranker.py
+++ b/data_tracker/signal_request_ranker.py
@@ -137,7 +137,6 @@ def main(date_time):
                 response_json = knackpy.update_record(
                     record,
                     obj,
-                    'id',
                     knack_creds['app_id'],
                     knack_creds['api_key']
                 )

--- a/data_tracker/street_seg_updater.py
+++ b/data_tracker/street_seg_updater.py
@@ -90,7 +90,6 @@ def main(date_time):
             response_json = knackpy.update_record(
                 record,
                 ref_obj[0],
-                'id',
                 knack_creds['app_id'],
                 knack_creds['api_key']
             )

--- a/data_tracker/traffic_reports.py
+++ b/data_tracker/traffic_reports.py
@@ -234,7 +234,6 @@ def main(date_time):
             res = knackpy.update_record(
                 record,
                 knack_obj,
-                'id',
                 knack_creds['app_id'],
                 knack_creds['api_key']
             )

--- a/open_data/dms_msg_pub.py
+++ b/open_data/dms_msg_pub.py
@@ -101,7 +101,6 @@ def main(date_time):
             response = knackpy.update_record(
                 record,
                 ref_obj[0],
-                'id',
                 knack_creds['app_id'],
                 knack_creds['api_key']
             )


### PR DESCRIPTION
A minor tweak for the latest version of Knackpy: it's no longer necessary to pass a record id key to the update_record method. The method defaults to the ID key 'id', which is what we were passing in every instance.