### PR TITLE
Log GRIDSMART Device Status

### DIFF
--- a/config/knack/config.py
+++ b/config/knack/config.py
@@ -23,7 +23,8 @@ cfg = {
         'location_fields' : {
             'lat' : 'LOCATION_latitude',
             'lon' : 'LOCATION_longitude'
-        }
+        },
+        'status_filter_comm_status' : ['TURNED_ON']
     },
     'signal_requests' : {
         'primary_key' : 'REQUEST_ID',
@@ -53,7 +54,8 @@ cfg = {
         'location_fields' : {
             'lat' : 'LOCATION_latitude',
             'lon' : 'LOCATION_longitude'
-        }
+        },
+        'status_filter_comm_status' : ['TURNED_ON']
     },
     'dms' : {
         'primary_key' : 'DMS_ID',
@@ -182,7 +184,8 @@ cfg = {
         'location_fields' : {
             'lat' : 'LOCATION_latitude',
             'lon' : 'LOCATION_longitude'
-        }
+        },
+        'status_filter_comm_status' : ['TURNED_ON']
     },
     'quote_of_the_week' : {
         'primary_key' : 'id',
@@ -235,6 +238,8 @@ cfg = {
         'include_ids' : True,
         'pub_log_id' : 'n5kp-f8k4',
         'ip_field' : 'DETECTOR_IP',
+        'status_field' : 'DETECTOR_STATUS',
+        'status_filter_comm_status' : ['OK', 'BROKEN', 'UNKNOWN']
     },
     'timed_corridors' : {
         'primary_key' : 'ATD_SYNC_SIGNAL_ID',

--- a/data_tracker/device_status_log.py
+++ b/data_tracker/device_status_log.py
@@ -68,7 +68,7 @@ def main():
 
         for device in kn.data:
             #  count stats only for devices that are TURNED_ON
-            if device[status_field] == status_filter_value:
+            if device[status_field] in status_filters:
                 status = device['IP_COMM_STATUS']
                 stats[status] += 1
 
@@ -107,7 +107,7 @@ def cli_args():
         'device_type',
         action="store",
         type=str,
-        choices=['signals', 'travel_sensors', 'cameras'],
+        choices=['signals', 'travel_sensors', 'cameras', 'gridsmart'],
         help='Type of device to calculate.'
     )
 
@@ -150,7 +150,7 @@ if __name__ == '__main__':
         
     primary_key = cfg[device_type]['primary_key']
     status_field = cfg[device_type]['status_field']
-    status_filter_value = 'TURNED_ON'
+    status_filters = cfg[device_type]['status_filter_comm_status']
 
     knack_creds = KNACK_CREDENTIALS[app_name]
 

--- a/shell_scripts/device_status_log_gridsmart.sh
+++ b/shell_scripts/device_status_log_gridsmart.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd ../data_tracker
+source activate datapub1
+python device_status_log.py gridsmart data_tracker_prod
+source deactivate


### PR DESCRIPTION
Update config and script logic to handle device records with varying status fields, rather than assume every device uses 'TURNED_ON.'
Plus shell scripts :)