### PR TITLE
Use Build Path in Logrotate Config

### DIFF
--- a/build.py
+++ b/build.py
@@ -7,6 +7,7 @@ import sys
 
 from config import CONFIG
 from config import DOCKER_BASE_CMD
+from config import LOGROTATE
 
 
 def checkVersion():
@@ -56,6 +57,9 @@ def listToFile(list_, filename, write_mode='a+'):
 if __name__ == '__main__':
     checkVersion()
 
+    crontab_filename = 'crontab.sh'
+    logrotate_filename = 'tdp.logrotate'
+
     #  Get the absolute path of the repository
     build_path = os.getcwd()
 
@@ -99,8 +103,21 @@ if __name__ == '__main__':
 
         crons.append(cron)
 
+    #  Write cron jobs
     crons.append('') #  ensures last line of crontab file is empty (as required)
-    listToFile(crons, 'crontab.sh', write_mode='a+')
+    listToFile(
+        crons, 
+        crontab_filename, 
+        write_mode='a+'
+    )
+
+    #  Write logrotate config
+    logrotate = LOGROTATE.replace('$BUILD_PATH', build_path)
+    listToFile(
+        [logrotate], 
+        logrotate_filename, 
+        write_mode='a+'
+    )
 
 
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#  Builds transportation-data-publshing shell scripts
+#  See http://github.com/cityofaustin/transportation-data-publishing
+#  requires Python 2.7+
+
+#  remove any shell scripts that happen to be in directory
+rm -f transportation-data-publishing/shell_scripts/*.sh
+
+#  build new shell scripts and crontab
+python build.py

--- a/config.py
+++ b/config.py
@@ -15,6 +15,17 @@ sudo docker run \\
     -c "$CMD"
 '''
 
+#  Logrotate config template
+LOGROTATE = '''
+$BUILD_PATH/transportation-data-publishing/log/*.log {
+    missingok
+    nocompress
+    nocreate
+    daily
+    rotate 7
+}
+'''
+
 #  Script configuration
 CONFIG = {
   'default_image' : 'tdp-py36',

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-#  Builds transportation-data-publshing shell scripts
-#  and deploys crontab and logrotate to Docker host
+#  Deploy crontab and logrotate to Docker host
 #  See http://github.com/cityofaustin/transportation-data-publishing
-#  requires Python 2.7+
-
-#  remove any shell scripts that happen to be in directory
-rm -f transportation-data-publishing/shell_scripts/*.sh
-
-#  build new shell scripts and crontab
-python build.py
-wait
 
 #  deploy crontab
 crontab < crontab.sh

--- a/tdp.logrotate
+++ b/tdp.logrotate
@@ -1,9 +1,2 @@
 #  Logrotate config for transportation-data-publishing script logs
-#  Copy to Docker host at /etc/logrotate.d
-/app/transportation-data-publishing/log/*.log {
-    missingok
-    nocompress
-    nocreate
-    daily
-    rotate 7
-}
+#  Will be copied to /etc/logrotate.d on Docker host


### PR DESCRIPTION
Use the current build path (os.getwcd()) when generating the logrotate config. Otherwise we don't where the log files are, so they don't rotate.