### PR TITLE
Use Token to Query Street Segments

### DIFF
--- a/transportation-data-publishing/data_tracker/street_seg_updater.py
+++ b/transportation-data-publishing/data_tracker/street_seg_updater.py
@@ -54,10 +54,17 @@ def main(date_time):
         for street_segment in kn.data:
             
             try:
-                segment_data = agolutil.query_atx_street(street_segment[primay_key])
+                token = agolutil.get_token(AGOL_CREDENTIALS)
+                features = agolutil.query_atx_street(street_segment[primay_key], token)
 
+                if features.get('features'):
+                    if len(features['features']) > 0:
+                        segment_data = features['features'][0]['attributes']
+                    else:
+                        unmatched_segments.append(street_segment[primay_key])
+                        continue
                 
-                if not segment_data:
+                else:
                     unmatched_segments.append(street_segment[primay_key])
                     continue
 

--- a/transportation-data-publishing/util/agolutil.py
+++ b/transportation-data-publishing/util/agolutil.py
@@ -162,7 +162,7 @@ def parse_attributes(query_results):
     return results
 
 
-def query_atx_street(segment_id):
+def query_atx_street(segment_id, token):
     print('Query atx street segment {}'.format(segment_id))
 
     url = 'http://services.arcgis.com/0L95CJ0VTaxqcmED/arcgis/rest/services/TRANSPORTATION_street_segment/FeatureServer/0/query'
@@ -171,19 +171,14 @@ def query_atx_street(segment_id):
         'f' : 'json',
         'where' : where,
         'returnGeometry' : False,
-        'outFields'  : '*'
+        'outFields'  : '*',
+        'token' : token
     }
     
     res = requests.post(url, params=params)
+    res.raise_for_status()
     
-    res = res.json()
-    
-    if 'features' in res:
-        if len(res['features']) > 0:
-            return res['features'][0]['attributes']
-
-    else:
-        return None
+    return res.json()
 
 
 def point_in_poly(service_name, layer_id, params):


### PR DESCRIPTION
Street segment updater was failing today because we weren't providing a token with our request. Apparently a token is required now. Not sure why. It's a public dataset. Hrmph. Probably a best practice going forward to include a token with any AGOL method.