### PR TITLE
Handle Unicode

### DIFF
--- a/transportation-data-publishing/data_tracker/backup.py
+++ b/transportation-data-publishing/data_tracker/backup.py
@@ -48,8 +48,14 @@ def main(date_time):
                 date_fields_kn = [kn.fields[f]['label'] for f in kn.fields if kn.fields[f]['type'] in ['date_time', 'date']]
 
                 kn.data = datautil.mills_to_iso(kn.data, date_fields_kn)
-                kn.to_csv(file_name)
                 
+                try:
+                    kn.to_csv(file_name)
+                
+                except UnicodeError:
+                    kn.data = [{key : str(d[key]).encode()} for d in kn.data for key in d ]
+                    kn.to_csv(file_name)
+
                 count += 1
             
             else:


### PR DESCRIPTION
Knack strings can contain unicode characters, and to this point we've not made any attempt to handle unicode. The issue finally came up with a bunk apostrpohe made it's way into one of..my change log entries caused the backup script to fail.

We should be handling this in knackpy's to_csv() method. For now we're encoding the entire dicionary if we catch a UnicodeError.