### PR TITLE
Logrotate and Traffic Incident Feed Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY requirements.txt /app/transportation-data-publishing
 
 RUN apt-get update
 
+#  Set Timezone :(  
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 #  Install cifs-utils to mount Windows network share
 RUN apt-get install -y cifs-utils
 

--- a/build.py
+++ b/build.py
@@ -1,5 +1,5 @@
 '''
-Generate shell scripts, logrotate config and crontab for deployment of 
+Generate shell scripts config and crontab for deployment of 
 transportation-data-publishing scripts.
 '''
 import os
@@ -8,7 +8,6 @@ import sys
 from config import CONFIG
 from config import CRONTAB
 from config import DOCKER_BASE_CMD
-from config import LOGROTATE
 
 
 def check_version():
@@ -63,7 +62,6 @@ if __name__ == '__main__':
     check_version()
 
     crontab_filename = 'crontab.sh'
-    logrotate_filename = 'tdp.logrotate'
 
     #  get the absolute path of the repository
     build_path = os.getcwd()
@@ -111,7 +109,3 @@ if __name__ == '__main__':
 
     #  write crontab
     list_to_file(crontab_filename, crons, header=CRONTAB, write_mode='w')
-
-    #  write logrotate
-    logrotate = LOGROTATE.replace('$BUILD_PATH', build_path)
-    list_to_file(logrotate_filename, [], header=logrotate, write_mode='w')

--- a/config.py
+++ b/config.py
@@ -21,24 +21,6 @@ sudo docker run \\
     -c "$CMD"
 '''
 
-#  Logrotate config template
-LOGROTATE = '''
-$BUILD_PATH/transportation-data-publishing/log/*.log {
-    missingok
-    nocompress
-    nocreate
-    daily
-    rotate 7
-}
-
-$BUILD_PATH/transportation-data-publishing/xml/*.xml {
-    missingok
-    nocompress
-    nocreate
-    weekly
-    rotate 0
-}
-'''
 
 #  Script configuration
 CONFIG = {

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,3 @@
 
 #  deploy crontab
 crontab < crontab.sh
-
-#  set logrotation
-cp tdp.logrotate /etc/logrotate.d

--- a/transportation-data-publishing/data_tracker/backup.py
+++ b/transportation-data-publishing/data_tracker/backup.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import pdb
 
@@ -9,12 +8,14 @@ import _setpath
 from config.secrets import *
 from util import emailutil
 from util import datautil
+from util import logutil
 
 now = arrow.now()
 script = os.path.basename(__file__).replace('.py', '.log')
+
 logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START AT {}'.format(str(now)))
+logger = logutil.timed_rotating_log(logfile)
+logger.info('START AT {}'.format(str(now)))
 
 objects = ['object_87', 'object_93', 'object_77', 'object_53', 'object_96', 'object_83', 'object_95', 'object_21', 'object_14', 'object_109', 'object_73', 'object_110', 'object_15', 'object_36', 'object_11', 'object_107', 'object_115', 'object_116', 'object_117', 'object_67', 'object_91', 'object_89', 'object_12', 'object_118', 'object_113', 'object_98', 'object_102', 'object_71', 'object_84', 'object_13', 'object_26', 'object_27', 'object_81', 'object_82', 'object_7', 'object_42', 'object_43', 'object_45', 'object_75', 'object_58', 'object_56', 'object_54', 'object_86', 'object_78', 'object_85', 'object_104', 'object_106', 'object_31', 'object_101', 'object_74', 'object_94', 'object_9', 'object_10', 'object_19', 'object_20', 'object_24', 'object_57', 'object_59', 'object_65', 'object_68', 'object_76', 'object_97', 'object_108']
 app_name = 'data_tracker_prod'
@@ -31,7 +32,7 @@ def main(date_time):
         count = 0
 
         for obj in objects:
-            logging.info( "backup {}".format(obj) )
+            logger.info( "backup {}".format(obj) )
 
             kn = knackpy.Knack(
                 obj=obj,
@@ -40,7 +41,7 @@ def main(date_time):
             )
 
             if kn.data:
-                logging.info( "total records: {}".format(len(kn.data)) )
+                logger.info( "total records: {}".format(len(kn.data)) )
 
                 today = date_time.format('YYYY_MM_DD')
                 

--- a/transportation-data-publishing/data_tracker/detection_status_signals.py
+++ b/transportation-data-publishing/data_tracker/detection_status_signals.py
@@ -16,6 +16,8 @@ import _setpath
 from config.secrets import *
 from util import datautil
 from util import emailutil
+from util import logutil
+
 
 def groupBySignal(detector_data):
     '''
@@ -135,15 +137,17 @@ def cli_args():
 
 if __name__ == '__main__':
 
-    now = arrow.now()
-
     #  init logging 
-    script = os.path.basename(__file__).replace('.py', '.log')
-    logfile = f'{LOG_DIRECTORY}/{script}'
-    logging.basicConfig(filename=logfile, level=logging.INFO)
-    logging.info('START AT {}'.format(str(now)))
+    script = os.path.basename(__file__).replace('.py', '')
+    logfile = f'{LOG_DIRECTORY}/{script}.log'
+    logger = logutil.timed_rotating_log(logfile)
+    
+    now = arrow.now()
+    logger.info('START AT {}'.format(str(now)))
 
     args = cli_args()
+    logger.info( 'args: {}'.format( str(args) ))
+
     app_name = args.app_name
 
     try:
@@ -245,16 +249,16 @@ if __name__ == '__main__':
             count_sig += 1
             count_status += 1
 
-        logging.info('{} signal records updated'.format(count_sig))
-        logging.info( '{} detection status log records updated'.format(count_status) )
-        logging.info('END AT {}'.format(str( arrow.now().format()) ))
+        logger.info('{} signal records updated'.format(count_sig))
+        logger.info( '{} detection status log records updated'.format(count_status) )
+        logger.info('END AT {}'.format(str( arrow.now().format()) ))
 
     except Exception as e:
         print('Failed to process data for {}'.format(arrow.now()))
         error_text = traceback.format_exc()
         email_subject = "Detection Status Update Failure"
         emailutil.send_email(ALERTS_DISTRIBUTION, email_subject, error_text, EMAIL['user'], EMAIL['password'])
-        logging.error(error_text)
+        logger.error(error_text)
         print(e)
         raise e
 

--- a/transportation-data-publishing/data_tracker/dms_msg_pub.py
+++ b/transportation-data-publishing/data_tracker/dms_msg_pub.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import pdb
 import sys
@@ -12,12 +11,17 @@ from util import kitsutil
 from util import datautil
 from util import emailutil
 from util import socratautil   
+from util import logutil
+
 
 then = arrow.now()
 
 script = os.path.basename(__file__).replace('.py', '.log')
 logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
+logger = logutil.timed_rotating_log(logfile)
+
+now = arrow.now()
+logger.info('START AT {}'.format(str(now)))
 
 #  config
 primay_key = 'DMS_ID'
@@ -112,4 +116,4 @@ def main(date_time):
  
 results = main(then)
 
-logging.info('Elapsed time: {}'.format(str(arrow.now() - then)))
+logger.info('Elapsed time: {}'.format(str(arrow.now() - then)))

--- a/transportation-data-publishing/data_tracker/esb_xml_send.py
+++ b/transportation-data-publishing/data_tracker/esb_xml_send.py
@@ -3,7 +3,6 @@ Generate XML message to update 311 Service Reqeusts
 via Enterprise Service Bus
 '''
 import argparse
-import logging
 import os
 import pdb
 import traceback
@@ -17,6 +16,7 @@ from config.esb.config import cfg
 from config.secrets import *
 from util import datautil
 from util import emailutil
+from util import logutil
 
 
 def get_record_id_from_file(directory, file):
@@ -151,14 +151,14 @@ def main(date_time):
                 method='update',
             )
 
-        logging.info('{} records transmitted.'.format(len(files)))
+        logger.info('{} records transmitted.'.format(len(files)))
         
 
     except Exception as e:
         print(f'Failed to process data for {date_time}. See logs for detail.')
         error_text = traceback.format_exc()
-        logging.error(str(e))
-        logging.error(error_text)
+        logger.error(str(e))
+        logger.error(error_text)
         
         emailutil.send_email(
             ALERTS_DISTRIBUTION,
@@ -171,16 +171,18 @@ def main(date_time):
         raise e
 
 if __name__ == '__main__':
-    args = cli_args()
-    app_name = args.app_name
-
-    now = arrow.now()
-
     #  init logging 
     script = os.path.basename(__file__).replace('.py', '.log')
     logfile = f'{LOG_DIRECTORY}/{script}'
-    logging.basicConfig(filename=logfile, level=logging.INFO)
-    logging.info('START AT {}'.format(str(now)))
+    logger = logutil.timed_rotating_log(logfile)
+
+    now = arrow.now()
+    logger.info('START AT {}'.format(str(now)))
+
+    args = cli_args()
+    logger.info( 'args: {}'.format( str(args) ))
+
+    app_name = args.app_name
 
     #  config
     knack_creds = KNACK_CREDENTIALS[app_name]
@@ -198,6 +200,6 @@ if __name__ == '__main__':
         os.makedirs(outpath)
 
     results = main(now)
-    logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
+    logger.info('END AT {}'.format(str( arrow.now().timestamp) ))
 
 

--- a/transportation-data-publishing/data_tracker/location_updater.py
+++ b/transportation-data-publishing/data_tracker/location_updater.py
@@ -3,7 +3,6 @@ Update Data Tracker location records with council district, engineer area,
 and jurisdiction attributes from from COA ArcGIS Online feature services
 '''
 import argparse
-import logging
 import os
 import pdb
 
@@ -15,7 +14,7 @@ from config.secrets import *
 from util import agolutil
 from util import datautil
 from util import emailutil
-
+from util import logutil
 
 #  config
 knack_creds = KNACK_CREDENTIALS
@@ -225,7 +224,7 @@ def main(date_time):
         count = 0
 
         if not kn.data:
-            logging.info('No new records to process')
+            logger.info('No new records to process')
             return None
 
         '''
@@ -256,7 +255,7 @@ def main(date_time):
                     )                    
                     
                     if res.get('error'):
-                        logging.info(res)
+                        logger.info(res)
                         raise Exception
 
                     if res.get('features'):
@@ -327,7 +326,7 @@ def main(date_time):
                 EMAIL['password']
             )
 
-        logging.info('{} records updated'.format(count))
+        logger.info('{} records updated'.format(count))
         return update_response
 
     except Exception as e:
@@ -345,15 +344,16 @@ def main(date_time):
         raise e
 
 if __name__ == '__main__':
-    args = cli_args()
-    app_name = args.app_name
-
-    now = arrow.now()
-    
     #  init logging 
     script = os.path.basename(__file__).replace('.py', '.log')
     logfile = f'{LOG_DIRECTORY}/{script}'
-    logging.basicConfig(filename=logfile, level=logging.INFO)
+    logger = logutil.timed_rotating_log(logfile)
+
+    now = arrow.now()
+    logger.info('START AT {}'.format(str(now)))
+
+    args = cli_args()
+    app_name = args.app_name
 
     results = main(now)
-    logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
+    logger.info('END AT {}'.format(str( arrow.now().timestamp) ))

--- a/transportation-data-publishing/data_tracker/secondary_signals_updater.py
+++ b/transportation-data-publishing/data_tracker/secondary_signals_updater.py
@@ -3,7 +3,6 @@ Update traffic signal records with secondary signal relationships
 '''
 import argparse
 import collections
-import logging
 import os
 import pdb
 import traceback
@@ -15,6 +14,7 @@ import _setpath
 from config.secrets import *
 from util import datautil
 from util import emailutil
+from util import logutil
 
 
 def cli_args():
@@ -138,11 +138,11 @@ def main(date_time):
         update_response = []
         
         if len(payload) == 0:
-            logging.info("No new secondary signals.")
+            logger.info("No new secondary signals.")
             return "No new secondary signals."
 
-        logging.info( "{} records to update".format(len(payload)) )
-        logging.info( "{} records to update".format(payload) )
+        logger.info( "{} records to update".format(len(payload)) )
+        logger.info( "{} records to update".format(payload) )
         
         for record in payload:
             count += 1
@@ -158,8 +158,8 @@ def main(date_time):
 
             update_response.append(res)
 
-        logging.info( "Record updates sent :{}".format(len(update_response)) )
-        logging.info( "Response: {}".format(update_response) )
+        logger.info( "Record updates sent :{}".format(len(update_response)) )
+        logger.info( "Response: {}".format(update_response) )
         return update_response
 
     except Exception as e:
@@ -178,26 +178,25 @@ def main(date_time):
         raise e
 
 if __name__ == '__main__':
-    #  parse command-line arguments
+    script = os.path.basename(__file__).replace('.py', '.log')
+    logfile = f'{LOG_DIRECTORY}/{script}'
+    logger = logutil.timed_rotating_log(logfile)
+
+    now = arrow.now()
+    logger.info('START AT {}'.format(str(now)))
+
     args = cli_args()
     app_name = args.app_name
 
-    now = arrow.now()
-
-    script = os.path.basename(__file__).replace('.py', '.log')
-    logfile = f'{LOG_DIRECTORY}/{script}'
-    logging.basicConfig(filename=logfile, level=logging.INFO)
-    logging.info('START AT {}'.format(str(now)))
-
     update_field = 'field_1329'  # SECONDARY_SIGNALS field
-    ref_obj = ['object_12']  #  Signals object
+    ref_obj = ['object_12']  #  signals object
     scene = 'scene_73'
     view = 'view_197'
 
     knack_creds = KNACK_CREDENTIALS[app_name]
 
     results = main(now)
-    logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
+    logger.info('END AT {}'.format(str( arrow.now().timestamp) ))
 
 print(results)
 

--- a/transportation-data-publishing/data_tracker/street_seg_updater.py
+++ b/transportation-data-publishing/data_tracker/street_seg_updater.py
@@ -2,7 +2,6 @@
 update Knack street segments with data from 
 COA ArcGIS Online Street Segment Feature Service
 '''
-import logging
 import os
 import pdb
 
@@ -14,21 +13,7 @@ from config.secrets import *
 from util import agolutil
 from util import emailutil
 from util import datautil
-
-
-now = arrow.now()
-
-script = os.path.basename(__file__).replace('.py', '.log')
-logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START AT {}'.format(str(now)))
-
-#  config
-primay_key = 'SEGMENT_ID_NUMBER'
-knack_creds = KNACK_CREDENTIALS['data_tracker_prod']
-ref_obj = ['object_7']
-scene = 'scene_424'
-view = 'view_1198'
+from util import logutil
 
 
 def main(date_time):
@@ -48,7 +33,7 @@ def main(date_time):
         unmatched_segments = []
         
         if not kn.data:
-            logging.info('No records to update.')
+            logger.info('No records to update.')
             return None
 
         for street_segment in kn.data:
@@ -105,7 +90,7 @@ def main(date_time):
             update_response.append(res)
 
         if (len(unmatched_segments) > 0):
-            logging.info( 'Unmatched Street Segments: {}'.format(unmatched_segments) )
+            logger.info( 'Unmatched Street Segments: {}'.format(unmatched_segments) )
             emailutil.send_email(ALERTS_DISTRIBUTION, 'Unmatched Street Segments', str(unmatched_segments), EMAIL['user'], EMAIL['password'])
 
         return update_response
@@ -117,10 +102,25 @@ def main(date_time):
         raise e
 
 
-results = main(now)
-logging.info('END AT {}'.format(str( arrow.now().timestamp) ))
+if __name__ == '__main__':
+    script = os.path.basename(__file__).replace('.py', '')
+    logfile = f'{LOG_DIRECTORY}/{script}.log'
+    logger = logutil.timed_rotating_log(logfile)
 
-print(results)
+    now = arrow.now()
+    logger.info('START AT {}'.format(str(now)))
+
+    #  config
+    primay_key = 'SEGMENT_ID_NUMBER'
+    knack_creds = KNACK_CREDENTIALS['data_tracker_prod']
+    ref_obj = ['object_7']
+    scene = 'scene_424'
+    view = 'view_1198'
+
+    results = main(now)
+    logger.info('END AT {}'.format(str( arrow.now().timestamp) ))
+
+    print(results)
 
 
 

--- a/transportation-data-publishing/data_tracker/tcp_business_days.py
+++ b/transportation-data-publishing/data_tracker/tcp_business_days.py
@@ -5,7 +5,6 @@ Developed specifically for measuring Traffic Control Plan (TCP) permit applicati
 '''
 import argparse
 from datetime import datetime
-import logging
 import os
 import pdb
 import traceback
@@ -19,7 +18,7 @@ import _setpath
 from config.secrets import *
 from util import datautil
 from util import emailutil
-
+from util import logutil
 
 def get_calendar():
     return CustomBusinessDay(calendar=USFederalHolidayCalendar())
@@ -149,7 +148,7 @@ def main(creds):
         calendar
     )
     
-    logging.info( '{} Records to Update'.format(len(kn.data) ))
+    logger.info( '{} Records to Update'.format(len(kn.data) ))
 
     if kn.data:    
         results = []
@@ -165,17 +164,17 @@ def main(creds):
 
 
 if __name__ == '__main__':
+    #  init logging 
     script = os.path.basename(__file__).replace('.py', '')
     logfile = f'{LOG_DIRECTORY}/{script}.log'
-    
-    logging.basicConfig(
-        filename=logfile,
-        level=logging.INFO
-    )
+    logger = logutil.timed_rotating_log(logfile)
 
+    now = datetime.today()
+    logger.info('START AT {}'.format(now))
+        
     try:
         args = cli_args()
-        logging.info( 'args: {}'.format( str(args) ) )
+        logger.info( 'args: {}'.format( str(args) ) )
         
         app_name = args.app_name
         knack_creds = KNACK_CREDENTIALS[app_name]
@@ -183,7 +182,7 @@ if __name__ == '__main__':
 
     except Exception as e:
         error_text = traceback.format_exc()
-        logging.error(error_text)
+        logger.error(error_text)
 
         email_subject = "Days Elapsed Update Failure"
 

--- a/transportation-data-publishing/open_data/cifs.py
+++ b/transportation-data-publishing/open_data/cifs.py
@@ -31,8 +31,8 @@ now_mills = now.timestamp * 1000
 
 script = os.path.basename(__file__).replace('.py', '.log')
 logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START AT {}'.format(now.format()))
+logger.basicConfig(filename=logfile, level=logger.INFO)
+logger.info('START AT {}'.format(now.format()))
 
 socrata_resource_id_json = 'fwsr-gb9r'
 socrata_resource_id_csv = 'aki2-nu5c'
@@ -189,12 +189,12 @@ def main():
 
     except Exception as e:
         error_text = traceback.format_exc()
-        logging.error(error_text)
+        logger.error(error_text)
         emailutil.send_email(ALERTS_DISTRIBUTION, 'CIFS Publication Failure', error_text, EMAIL['user'], EMAIL['password'])
 
 main()
 
-logging.info( 'END AT: {}'.format( arrow.now().format() ))
+logger.info( 'END AT: {}'.format( arrow.now().format() ))
 
 
 # def build_incident(feature, fieldmap):

--- a/transportation-data-publishing/open_data/radar_count_pub.py
+++ b/transportation-data-publishing/open_data/radar_count_pub.py
@@ -4,7 +4,6 @@ new records to City of Austin Open Data Portal.
 '''
 import argparse
 import hashlib
-import logging
 import os
 import pdb
 import sys
@@ -16,14 +15,16 @@ import _setpath
 from config.secrets import *
 from util import datautil
 from util import emailutil
+from util import logutil
 from util import kitsutil
 from util import socratautil   
 
-then = arrow.now()
-script = os.path.basename(__file__).replace('.py', '.log')
-logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START AT {}'.format(str(then)))
+script = os.path.basename(__file__).replace('.py', '')
+logfile = f'{LOG_DIRECTORY}/{script}.log'
+logger = logutil.timed_rotating_log(logfile)
+
+now = arrow.now()
+logger.info('START AT {}'.format(str(now)))
 
 socrata_resource = 'i626-g7ub'
 
@@ -146,7 +147,7 @@ def main(date_time):
                 '''.format(strtime)
         
         else:
-            logging.info('No Data to export, try: count_data_pub.py -replace')
+            logger.info('No Data to export, try: count_data_pub.py -replace')
             return True
 
         kits_data = kitsutil.data_as_dict(
@@ -191,7 +192,7 @@ def main(date_time):
             kits_data
         )
 
-        logging.info(len(socrata_payload))
+        logger.info(len(socrata_payload))
 
         status_upsert_response = socratautil.upsert_data(
             SOCRATA_CREDENTIALS,
@@ -199,7 +200,7 @@ def main(date_time):
             socrata_resource
         )
 
-        logging.info(status_upsert_response)
+        logger.info(status_upsert_response)
 
     except Exception as e:
         print('Failed to process data for {}'.format(date_time))
@@ -235,6 +236,6 @@ if __name__ == '__main__':
     #  parse command-line arguments    
     args = cli_args()
     replace = args.replace
-    results = main(then)
+    results = main(now)
 
-logging.info('Elapsed time: {}'.format(str(arrow.now() - then)))
+logger.info('Elapsed time: {}'.format(str(arrow.now() - now)))

--- a/transportation-data-publishing/traffic_study/traffic_study_cls.py
+++ b/transportation-data-publishing/traffic_study/traffic_study_cls.py
@@ -4,7 +4,6 @@ inserted into ArcSDE database and published as open data
 '''
 import csv
 import hashlib
-import logging
 import os
 import pdb
 import traceback
@@ -14,13 +13,14 @@ import arrow
 import _setpath
 from config.secrets import *
 from util import emailutil
+from util import logutil
+
+script = os.path.basename(__file__).replace('.py', '')
+logfile = f'{LOG_DIRECTORY}/{script}.log'
+logger = logutil.timed_rotating_log(logfile)
 
 now = arrow.now()
-
-script = os.path.basename(__file__).replace('.py', '.log')
-logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START CLS AT {}'.format(str(now)))
+logger.info('START AT {}'.format(str(now)))
 
 root_dir = TRAFFIC_COUNT_TIMEMARK_DIR
 out_dir = TRAFFIC_COUNT_OUTPUT_CLASS_DIR
@@ -211,15 +211,15 @@ def main():
             else:
                 continue
 
-    logging.info('{} files processed'.format(count))
+    logger.info('{} files processed'.format(count))
 
 try:
     main()
-    logging.info('END AT: {}'.format(arrow.now().format()))
+    logger.info('END AT: {}'.format(arrow.now().format()))
 
 except Exception as e:
         error_text = traceback.format_exc()
-        logging.error(error_text)
+        logger.error(error_text)
         emailutil.send_email(
             ALERTS_DISTRIBUTION,
             'Traffic Study Classification Process Failure',

--- a/transportation-data-publishing/traffic_study/traffic_study_locations.py
+++ b/transportation-data-publishing/traffic_study/traffic_study_locations.py
@@ -3,7 +3,6 @@ Download traffic study locations form ArcGIS Online
 and publish to Austin's Open Data Portal
 '''
 import csv
-import logging
 import os
 import pdb
 import traceback
@@ -12,9 +11,11 @@ import arrow
 
 import _setpath
 from config.secrets import *
-from util import emailutil
-from util import socratautil
 from util import agolutil
+from util import emailutil
+from util import logutil
+from util import socratautil
+
 
 socrata_creds = SOCRATA_CREDENTIALS
 socrata_resource_id = 'jqhg-imb3'
@@ -74,12 +75,12 @@ def main():
 
 if __name__ == '__main__':
 
+    script = os.path.basename(__file__).replace('.py', '')
+    logfile = f'{LOG_DIRECTORY}/{script}.log'
+    logger = logutil.timed_rotating_log(logfile)
+
     now = arrow.now()
-    
-    script = os.path.basename(__file__).replace('.py', '.log')
-    logfile = f'{LOG_DIRECTORY}/{script}'
-    logging.basicConfig(filename=logfile, level=logging.INFO)
-    logging.info('START TRAFFIC STUDY LOCATIONS AT {}'.format(str(now)))
+    logger.info('START AT {}'.format(str(now)))
 
     try:
         results = main()
@@ -87,7 +88,7 @@ if __name__ == '__main__':
     except Exception as e:
         error_text = traceback.format_exc()
         print(error_text)
-        logging.error(error_text)
+        logger.error(error_text)
         emailutil.send_email(
             ALERTS_DISTRIBUTION,
             'Traffic Count Locations Process Failure',
@@ -97,4 +98,4 @@ if __name__ == '__main__':
         )
         raise e
 
-    logging.info('END AT: {}'.format(arrow.now().format()))
+    logger.info('END AT: {}'.format(arrow.now().format()))

--- a/transportation-data-publishing/traffic_study/traffic_study_spd.py
+++ b/transportation-data-publishing/traffic_study/traffic_study_spd.py
@@ -4,7 +4,6 @@ inserted into ArcSDE database
 '''
 import csv
 import hashlib
-import logging
 import os
 import pdb
 import traceback
@@ -14,13 +13,14 @@ import arrow
 import _setpath
 from config.secrets import *
 from util import emailutil
+from util import logutil
+
+script = os.path.basename(__file__).replace('.py', '')
+logfile = f'{LOG_DIRECTORY}/{script}.log'
+logger = logutil.timed_rotating_log(logfile)
 
 now = arrow.now()
-
-script = os.path.basename(__file__).replace('.py', '.log')
-logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START SPD AT {}'.format(str(now)))
+logger.info('START AT {}'.format(str(now)))
 
 root_dir = TRAFFIC_COUNT_TIMEMARK_DIR
 out_dir = TRAFFIC_COUNT_OUTPUT_SPD_DIR
@@ -194,15 +194,15 @@ def main():
             else:
                 continue
 
-    logging.info('{} files processed'.format(count))
+    logger.info('{} files processed'.format(count))
 
 try:
     main()
-    logging.info('END AT: {}'.format(arrow.now().format()))
+    logger.info('END AT: {}'.format(arrow.now().format()))
 
 except Exception as e:
     error_text = traceback.format_exc()
-    logging.error(error_text)
+    logger.error(error_text)
     emailutil.send_email(
         ALERTS_DISTRIBUTION,
         'Traffic Study Speed Process Failure',

--- a/transportation-data-publishing/traffic_study/traffic_study_vol.py
+++ b/transportation-data-publishing/traffic_study/traffic_study_vol.py
@@ -4,7 +4,6 @@ inserted into ArcSDE database
 '''
 import csv
 import hashlib
-import logging
 import os
 import pdb
 import traceback
@@ -14,13 +13,14 @@ import arrow
 import _setpath
 from config.secrets import *
 from util import emailutil
+from util import logutil
+
+script = os.path.basename(__file__).replace('.py', '')
+logfile = f'{LOG_DIRECTORY}/{script}.log'
+logger = logutil.timed_rotating_log(logfile)
 
 now = arrow.now()
-
-script = os.path.basename(__file__).replace('.py', '.log')
-logfile = f'{LOG_DIRECTORY}/{script}'
-logging.basicConfig(filename=logfile, level=logging.INFO)
-logging.info('START VOL AT {}'.format(str(now)))
+logger.info('START AT {}'.format(str(now)))
 
 root_dir = TRAFFIC_COUNT_TIMEMARK_DIR
 out_dir = TRAFFIC_COUNT_OUTPUT_VOL_DIR
@@ -174,16 +174,16 @@ def main():
             else:
                 continue
 
-    logging.info('{} files processed'.format(count))
+    logger.info('{} files processed'.format(count))
 
 try:
     main()
-    logging.info('END AT: {}'.format(arrow.now().format()))
+    logger.info('END AT: {}'.format(arrow.now().format()))
 
 except Exception as e:
     error_text = traceback.format_exc()
     print(error_text)
-    logging.error(error_text)
+    logger.error(error_text)
     emailutil.send_email(
         ALERTS_DISTRIBUTION,
         'Traffic Study Volume Process Failure',

--- a/transportation-data-publishing/util/datautil.py
+++ b/transportation-data-publishing/util/datautil.py
@@ -179,7 +179,7 @@ def unix_to_iso(dicts, **options):
                         record[key] = d.format(options['out_format'])
                     
                     except ValueError:
-                        logging.info('{} not a valid unix timestamp'.format(record[key]))
+                        logger.info('{} not a valid unix timestamp'.format(record[key]))
                         continue
 
     return dicts

--- a/transportation-data-publishing/util/logutil.py
+++ b/transportation-data-publishing/util/logutil.py
@@ -1,0 +1,18 @@
+import logging
+from logging.handlers import TimedRotatingFileHandler
+
+def timed_rotating_log(path, when='D', interval=1, backupCount=5):
+    logger = logging.getLogger('Rotating Log')
+    
+    logger.setLevel(logging.INFO)
+ 
+    handler = TimedRotatingFileHandler(
+        path,
+        when=when,
+        interval=interval,
+        backupCount=backupCount
+    )
+
+    logger.addHandler(handler)
+
+    return logger


### PR DESCRIPTION
The traffic incident feed (or our script) does an odd thing where sometimes incidents will "disapear", only to re-appear on subsequent requests (e.g. 5 min later). Our old logic would assum these incidents were resolved and archive them. This would cause a unique ID collision when the incident reappeared. This script has been updated to query the incident database for each "new" incident before creating them in the database. Ideally, we wouldn't do this silly exercise of parsing a COA public safety feed--we would extract the incident data directly from the source in the CAD system. But, well, one battle at a time, right?

With this commit we also also introduce the logutil, which makes use of the TimedRotatingFileHandler class to rotate log files. Niiiiice.