### PR TITLE
Remove Empty Strings from Payload

### DIFF
--- a/transportation-data-publishing/data_tracker/markings_agol.py
+++ b/transportation-data-publishing/data_tracker/markings_agol.py
@@ -99,6 +99,14 @@ config = [
 ]
 
 
+def remove_empty_strings(records):
+    new_records = []
+    for record in records:
+        new_record = { key : record[key] for key in record.keys() if not (type(record[key]) == str and not record[key]) }
+        new_records.append(new_record)
+    return new_records
+
+
 def append_paths(
     records,
     features,
@@ -260,6 +268,8 @@ def main(config, job):
                 records, in_fieldname="ATTACHMENT", out_fieldname="ATTACHMENT_URL"
             )
 
+        records = remove_empty_strings(records) # AGOL has unexepected handling of empty values
+        
         update_layer = agolutil.get_item(
             auth=AGOL_CREDENTIALS,
             service_id=cfg["service_id"],


### PR DESCRIPTION
ArcGIS Online does not like empty strings in date fields (it converts them to 1/1/1899, so we're removing empty strings from the payload before uploading.