### PR TITLE
Fix Timebin Bug and Optimize 

### DIFF
--- a/transportation-data-publishing/open_data/radar_count_pub.py
+++ b/transportation-data-publishing/open_data/radar_count_pub.py
@@ -58,8 +58,9 @@ def get_timebin(minute, hour):
         hour = hour + 1 if hour != 23 else 0
 
     timebin = "{}:{}".format(hour, minute)
-
-    return arrow.get(timebin, "H:m").format("HH:mm")
+    minute = str(minute).zfill(2)
+    hour = str(hour).zfill(2)
+    return "{}:{}".format(hour, minute)
 
 
 def get_direction(lane):


### PR DESCRIPTION
A bug cropped up in get_timebin() in which we weren't properly handling records which had been rounded to 60 minutes. I fixed the logic there to make sure the hour rolls back to 0 in cases where we have a timestamp like 23:60.

We were also using arrow.get().format() to coerce the minute and hour values into a hh:mm format.  (e.g., 1:0 to 01:00). This was really, really slow. I replaced this method with the magical built-in .zfill() string method, which has drasitically improved performance.