### PR TITLE
dockless trip pub

### DIFF
--- a/transportation-data-publishing/config/postgrest/config.py
+++ b/transportation-data-publishing/config/postgrest/config.py
@@ -2,6 +2,7 @@ PGREST_PUB = {
     "traffic_reports": {
         "pgrest_base_url": "http://transportation-data.austintexas.io/traffic_reports",
         "primary_key": "traffic_report_id",
+        'limit' : 2000000,
         "modified_date_field": "traffic_report_status_date_time",
         "service_id": "444c8a2b4388485283c2968bd99ddf6c",
         "socrata_resource_id": "dx9v-zd7x",
@@ -10,6 +11,22 @@ PGREST_PUB = {
             "lon": "longitude",
             "location_field": "location",
         },
+        "date_fields" : [
+            "traffic_report_status_date_time",
+            "published_date",
+        ]
+    },
+    "dockless_trips": {
+        "pgrest_base_url": "http://transportation-data.austintexas.io/dockless_public",
+        "primary_key": "trip_id",
+        'limit' : 2000000,
+        "modified_date_field": "modified_date",
+        "socrata_resource_id": "k5pc-e6wr",
+        "date_fields" : [
+            "start_time",
+            "end_time",
+            "modified_date"
+        ]
     }
 }
 

--- a/transportation-data-publishing/open_data/pgrest_data_pub.py
+++ b/transportation-data-publishing/open_data/pgrest_data_pub.py
@@ -85,6 +85,8 @@ def main():
 
     cfg_dataset = cfg[args.dataset]
 
+    limit = cfg_dataset.get('limit')
+
     last_run_date = args.last_run_date
 
     if not last_run_date or args.replace:
@@ -97,15 +99,12 @@ def main():
     
     query_string = after_date_query(cfg_dataset["modified_date_field"], last_run_date)
 
-    records = pgrest.select(query_string)
-
+    records = pgrest.select(query_string, limit=limit)
+    
     if not records:
         return 0
 
-    date_fields = [
-        "traffic_report_status_date_time",
-        "published_date",
-    ]  # TODO: extract from API definition
+    date_fields = cfg_dataset.get('date_fields')
 
     if args.destination[0] == "socrata":
         pub = socrata_pub(records, cfg_dataset, args.replace, date_fields=date_fields)


### PR DESCRIPTION
This commit enables publishing of dockless trip data from our public postgrest endpoint at transportation-data.austintexas.io to the Open Data Portal (socrata).

- add config for `dockless_trips` to existing postgrest > socrata publishing script (`pgrest_data_pub.py`)
- tweak publishing config and remove some hard-coded values