### PR TITLE
Use pgrest-friendly data format

### DIFF
--- a/transportation-data-publishing/open_data/pgrest_data_pub.py
+++ b/transportation-data-publishing/open_data/pgrest_data_pub.py
@@ -7,10 +7,10 @@ modified date field defined in the configuration file. Alternatively use
 with --replace.
 """
 import argparse
+from datetime import datetime
 import pdb
 import sys
 
-import arrow
 from pypgrest import Postgrest
 from tdutils import argutil
 from tdutils import datautil
@@ -65,7 +65,8 @@ def main():
     if not args.last_run_date or args.replace:
         last_run_date = "1970-01-01T00:00:00"
     else:
-        last_run_date = arrow.get(args.last_run_date).format()
+        last_run_date = datetime.utcfromtimestamp(int(args.last_run_date))
+        last_run_date = last_run_date.isoformat()
 
     pgrest = Postgrest(cfg_dataset["pgrest_base_url"], auth=JOB_DB_API_TOKEN)
     '''


### PR DESCRIPTION
 Turns out we were not properly handling/formatting the  `--last_run_date` param in postgrest to socrata publisher. The param is submitted via client arg as a unix timetstamp, converted to an ISO string, and then used as the basis of a query to postgrest for the most recently modified records.

We were using `arrow` for this, and it's default format string was not ISO8601, and it was causing postgrest to only parse the date, and not the time, when handling the query.

We're now using built-in `datetime` methods (yay), and we're making sure the timestamp in the query string is ISO8601.