### PR TITLE
Upgrade to Pandas v1.0.01 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ dropbox
 feedparser==5.2.1
 fulcrum
 knackpy
-pandas
+pandas==1.0.1
 pymssql
 pyyaml
 yagmail

--- a/transportation-data-publishing/data_tracker/tcp_business_days.py
+++ b/transportation-data-publishing/data_tracker/tcp_business_days.py
@@ -107,7 +107,8 @@ def business_days_elapsed(start, end, calendar):
     Returns:
         TYPE: Description
     """
-    index = pd.DatetimeIndex(start=start, end=end, freq=calendar)
+    date_range = pd.date_range(start=start, end=end, freq=calendar)
+    index = pd.DatetimeIndex(date_range)
     elapsed = len(index) - 1
     return elapsed
 
@@ -166,8 +167,6 @@ def main():
     kn.data = handle_records(
         kn.data, config["start_key"], config["end_key"], config["elapsed_key"], calendar
     )
-
-    # logger.info( '{} Records to Update'.format(len(kn.data) ))
 
     if kn.data:
         kn.data = datautil.reduce_to_keys(kn.data, config["update_fields"])


### PR DESCRIPTION
This updates our use of `DataTimeIndex` to comply w/ pandas v1.0:

> Removed the previously deprecated keywords “start”, “end”, and “periods” from the DatetimeIndex, TimedeltaIndex, and PeriodIndex constructors; use date_range(), timedelta_range(), and period_range() instead (GH23919)

And it locks in pandas v1.0.1 into the requirements.txt for this docker image.