### PR TITLE
Use new signal engineer area layer

### DIFF
--- a/transportation-data-publishing/config/knack/config.py
+++ b/transportation-data-publishing/config/knack/config.py
@@ -480,7 +480,7 @@ LOCATION_UPDATER = {
             "handle_features": "use_first",
         },
         {
-            "service_name": "ATD_signal_engineer_areas",
+            "service_name": "TRANSPORTATION_signal_engineer_areas",
             "outFields": "SIGNAL_ENG_AREA",
             "updateFields": ["SIGNAL_ENG_AREA"],
             "layer_id": 0,


### PR DESCRIPTION
Towards fixing https://github.com/cityofaustin/atd-data-tech/issues/9678.

The[ location update script](https://github.com/cityofaustin/atd-data-publishing/blob/production/transportation-data-publishing/data_tracker/location_updater.py) was pointing to an old signal engineer area layer. This change points the script to the official GIS datamart layer.