### PR TITLE
Use new postgrest endpoint

### DIFF
--- a/transportation-data-publishing/config/postgrest/config.py
+++ b/transportation-data-publishing/config/postgrest/config.py
@@ -1,6 +1,6 @@
 PGREST_PUB = {
     "traffic_reports": {
-        "pgrest_base_url": "http://transportation-data-01-58741847.us-east-1.elb.amazonaws.com/traffic_reports",
+        "pgrest_base_url": "https://atd-postgrest.austinmobility.io/traffic_reports",
         "primary_key": "traffic_report_id",
         'limit' : 2000000,
         "modified_date_field": "traffic_report_status_date_time",
@@ -15,24 +15,12 @@ PGREST_PUB = {
             "traffic_report_status_date_time",
             "published_date",
         ]
-    },
-    "dockless_trips": {
-        "pgrest_base_url": "http://transportation-data-01-58741847.us-east-1.elb.amazonaws.com/dockless_public",
-        "primary_key": "trip_id",
-        'limit' : 100000,
-        "modified_date_field": "modified_date",
-        "socrata_resource_id": "7d8e-dm7r",
-        "date_fields" : [
-            "start_time",
-            "end_time",
-            "modified_date"
-        ]
     }
 }
 
 TRAFFIC_REPORT_SCRAPER = {
     "feed_url": "http://www.ci.austin.tx.us/qact/qact_rss.cfm",
-    "endpoint": "http://transportation-data-01-58741847.us-east-1.elb.amazonaws.com/traffic_reports",
+    "endpoint": "http://https://atd-postgrest.austinmobility.io/traffic_reports",
     "primary_key": "traffic_report_id",
     "status_field": "traffic_report_status",
     "date_field": "published_date",

--- a/transportation-data-publishing/config/postgrest/config.py
+++ b/transportation-data-publishing/config/postgrest/config.py
@@ -20,7 +20,7 @@ PGREST_PUB = {
 
 TRAFFIC_REPORT_SCRAPER = {
     "feed_url": "http://www.ci.austin.tx.us/qact/qact_rss.cfm",
-    "endpoint": "http://https://atd-postgrest.austinmobility.io/traffic_reports",
+    "endpoint": "https://atd-postgrest.austinmobility.io/traffic_reports",
     "primary_key": "traffic_report_id",
     "status_field": "traffic_report_status",
     "date_field": "published_date",


### PR DESCRIPTION
We moved the legacy scripts postgrest to a new AWS account. 