### PR TITLE
Bump socrata util

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ atd-jobs-util
 atd-kits-util
 atd-knack-util
 atd-log-util
-atd-socrata-util==0.0.10
+atd-socrata-util==0.0.11
 bs4
 dropbox
 feedparser==5.2.1


### PR DESCRIPTION
We need to use the newer socrata util which has the new datahub endpoint.

See: https://github.com/cityofaustin/atd-data-utilities/pull/29

Also: https://pypi.org/project/atd-socrata-util/
